### PR TITLE
new command 'Read' which fetches data from specified filed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{ Parser, Subcommand };
+use clap::{Parser, Subcommand};
 use std::collections::HashSet;
 use std::fs;
 
@@ -40,14 +40,20 @@ fn main() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::PS { cpu_cutoff_percent, mem_cutoff_percent } => {
+        Commands::PS {
+            cpu_cutoff_percent,
+            mem_cutoff_percent,
+        } => {
             ps::create_snapshot(*cpu_cutoff_percent, *mem_cutoff_percent);
         }
         Commands::Analyze { file_name } => {
             let users = read_users(file_name);
             dbg!(users);
         }
-        Commands::Read { data_field, data_dir } => {
+        Commands::Read {
+            data_field,
+            data_dir,
+        } => {
             let data = read_field::read_field(data_field, data_dir);
             dbg!(read_field::rank_data(&data));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use clap::{Parser, Subcommand};
+use clap::{ Parser, Subcommand };
 use std::collections::HashSet;
 use std::fs;
 
 mod command;
 mod ps;
+mod read_field;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -26,21 +27,29 @@ enum Commands {
         #[arg(long)]
         file_name: String,
     },
+    // fetches array of specified filed (user/process/etc.) sorted by number of occurrences in files in specified directory
+    Read {
+        #[arg(long)]
+        data_dir: String,
+        #[arg(long)]
+        data_field: i32,
+    },
 }
 
 fn main() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::PS {
-            cpu_cutoff_percent,
-            mem_cutoff_percent,
-        } => {
+        Commands::PS { cpu_cutoff_percent, mem_cutoff_percent } => {
             ps::create_snapshot(*cpu_cutoff_percent, *mem_cutoff_percent);
         }
         Commands::Analyze { file_name } => {
             let users = read_users(file_name);
             dbg!(users);
+        }
+        Commands::Read { data_field, data_dir } => {
+            let data = read_field::read_field(data_field, data_dir);
+            dbg!(read_field::rank_data(&data));
         }
     }
 }

--- a/src/read_field.rs
+++ b/src/read_field.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+use std::fs;
+
+pub fn rank_data(entries: &HashMap<String, i32>) -> Vec<(String, i32)> {
+    let mut ranked: Vec<(String, i32)> = entries
+        .iter()
+        .map(|(k, v)| (k.clone(), *v))
+        .collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+
+    ranked
+}
+
+pub fn read_field(field: &i32, dir_path: &str) -> HashMap<String, i32> {
+    let error_message = format!("something went wrong reading directory {}", dir_path);
+    let file_names = fs::read_dir(dir_path).expect(&error_message);
+
+    let mut field_data = HashMap::new();
+
+    for path in file_names {
+        let file_name = path.expect(&error_message).path();
+        if file_name.is_dir() {
+            let subdir_field_data = read_field(field, file_name.to_str().unwrap());
+            field_data.extend(subdir_field_data);
+        } else {
+            let contents = fs::read_to_string(file_name).expect(&error_message);
+            let lines = contents.lines();
+
+            for line in lines {
+                let words: Vec<&str> = line.split(',').collect();
+                let entry = words[*field as usize].parse().unwrap();
+                let count = field_data.entry(entry).or_insert(0);
+                *count += 1;
+            }
+        }
+    }
+
+    field_data
+}

--- a/src/read_field.rs
+++ b/src/read_field.rs
@@ -4,10 +4,7 @@ use std::collections::HashMap;
 use std::fs;
 
 pub fn rank_data(entries: &HashMap<String, i32>) -> Vec<(String, i32)> {
-    let mut ranked: Vec<(String, i32)> = entries
-        .iter()
-        .map(|(k, v)| (k.clone(), *v))
-        .collect();
+    let mut ranked: Vec<(String, i32)> = entries.iter().map(|(k, v)| (k.clone(), *v)).collect();
     ranked.sort_by(|a, b| b.1.cmp(&a.1));
 
     ranked
@@ -25,10 +22,8 @@ pub fn read_field(field: &i32, dir_path: &str) -> HashMap<String, i32> {
             let subdir_field_data = read_field(field, file_name.to_str().unwrap());
             field_data.extend(subdir_field_data);
         } else {
-            let error_message = format!(
-                "something went wrong reading file {}",
-                file_name.display()
-            );
+            let error_message =
+                format!("something went wrong reading file {}", file_name.display());
             let contents = fs::read_to_string(file_name).expect(&error_message);
             let lines = contents.lines();
 

--- a/src/read_field.rs
+++ b/src/read_field.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 use std::collections::HashMap;
 use std::fs;
 
@@ -23,6 +25,10 @@ pub fn read_field(field: &i32, dir_path: &str) -> HashMap<String, i32> {
             let subdir_field_data = read_field(field, file_name.to_str().unwrap());
             field_data.extend(subdir_field_data);
         } else {
+            let error_message = format!(
+                "something went wrong reading file {}",
+                file_name.display()
+            );
             let contents = fs::read_to_string(file_name).expect(&error_message);
             let lines = contents.lines();
 


### PR DESCRIPTION
Didn't want to interfere with the Analyze command and read_users function, so I made the (temporary) new command 'Read'.  It takes arguments data_dir and data_field, where data_dir is the directory of csv files and data_field is an integer indicating what field to read (0=time stamp, 1=hostname, 2 = corse on node, etc.)  

```$ sonar read --data-dir=2023 --data-field=5 ``` will for example fetch the data_field=5 (correspond to processes) from all readable files in 2023 and subdirectories. Will fail if it encounters unreadable files like compressed files. 

New functions are in read_fields.rs. I made the functions general to replace read_users and open up other fields. The function only accepts directories as argument and not single files as I didn't see an immediate reason to analyze single files. 