### PR TITLE
log_cmderror is only used in one file, moving definition there

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,3 @@ fn main() {
         }
     }
 }
-
-fn log_cmderror(msg: &str) {
-    // TODO (issue 52): Implement some sensible logging maybe
-    eprintln!("SONAR ERROR: {:?}", msg);
-}

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -4,7 +4,6 @@
 use crate::amd;
 use crate::command::CmdError;
 use crate::jobs;
-use crate::log_cmderror;
 use crate::nvidia;
 use crate::process;
 use crate::util::{three_places, time_iso8601};
@@ -285,4 +284,9 @@ pub fn create_snapshot(
     }
 
     writer.flush().unwrap();
+}
+
+fn log_cmderror(msg: &str) {
+    // TODO (issue 52): Implement some sensible logging maybe
+    eprintln!("SONAR ERROR: {:?}", msg);
 }


### PR DESCRIPTION
later we can use something from
https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/log.html