### PR TITLE
update timestamp function; closes #34, closes #64

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Here is an example output:
 ```console
 $ sonar ps
 
-2023-01-31T13:34:47.683582663+00:00,somehost,8,user,,alacritty,3.7,214932
-2023-01-31T13:34:47.683582663+00:00,somehost,8,user,,slack,2.4,1328412
-2023-01-31T13:34:47.683582663+00:00,somehost,8,user,,X,0.8,173148
-2023-01-31T13:34:47.683582663+00:00,somehost,8,user,,brave,15.5,7085968
-2023-01-31T13:34:47.683582663+00:00,somehost,8,user,,.zoom,37.8,1722564
+2023-07-27T18:29:17+02:00,somehost,8,user,,alacritty,3.7,214932
+2023-07-27T18:29:17+02:00,somehost,8,user,,slack,2.4,1328412
+2023-07-27T18:29:17+02:00,somehost,8,user,,X,0.8,173148
+2023-07-27T18:29:17+02:00,somehost,8,user,,brave,15.5,7085968
+2023-07-27T18:29:17+02:00,somehost,8,user,,.zoom,37.8,1722564
 ```
 
 The columns are:

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use chrono::prelude::{DateTime, Utc};
+use chrono::prelude::Local;
 
 // Populate a HashMap.
 #[cfg(test)]
@@ -19,8 +19,8 @@ pub(crate) use map;
 
 // Get current time as an ISO time stamp.
 pub fn time_iso8601() -> String {
-    let dt: DateTime<Utc> = std::time::SystemTime::now().into();
-    format!("{}", dt.format("%+"))
+    let local_time = Local::now();
+    format!("{}", local_time.format("%Y-%m-%dT%H:%M:%S%Z"))
 }
 
 // Carve up a line of text into space-separated chunks + the start indices of the chunks.


### PR DESCRIPTION
- do not write sub-second precision
- write data in local time, but with timezone information