### PR TITLE
make output fields self-identifying; closes #41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 
 [[package]]
 name = "sonar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonar"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -86,22 +86,45 @@ Here is an example output:
 ```console
 $ sonar ps
 
-2023-07-27T18:29:17+02:00,somehost,8,user,,alacritty,3.7,214932
-2023-07-27T18:29:17+02:00,somehost,8,user,,slack,2.4,1328412
-2023-07-27T18:29:17+02:00,somehost,8,user,,X,0.8,173148
-2023-07-27T18:29:17+02:00,somehost,8,user,,brave,15.5,7085968
-2023-07-27T18:29:17+02:00,somehost,8,user,,.zoom,37.8,1722564
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=.vim-wrapped,cpu%=1.9,cpukib=7228,gpus={},gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=node,cpu%=1.8,cpukib=79332,gpus={},gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=slack,cpu%=0.7,cpukib=591720,gpus={},gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=X,cpu%=1.5,cpukib=224416,gpus={},gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=brave,cpu%=12.1,cpukib=3075300,gpus={},gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=alacritty,cpu%=1.2,cpukib=286196,gpus={},gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=sonar,cpu%=9,cpukib=372,gpus={},gpu%=0,gpumem%=0,gpukib=0
 ```
 
 The columns are:
-- time stamp
-- hostname
-- number of cores on this node
-- user
-- Slurm job ID (empty if not applicable)
-- process
-- CPU percentage (as they come out of `ps`)
-- memory used in KiB
+- `v`: version (in the format n.m.o, following semantic versioning)
+- `time`: local time stamp (in ISO time without fractional seconds but with TZO)
+- `host`: host name (FQDN)
+- `cores`: number of cores on this node (positive integer)
+- `user` : username owning the process/command (it can also be "unknown" and "zombie")
+- `job`: job ID (positive integer; 0 if not applicable)
+- `cmd`: process/command
+- `cpu%`: CPU percentage (in percent of one core; as they come out of `ps`)
+- `cpukib`: CPU memory used in KiB
+- `gpus`: GPU devices (the card indices are 1-based; more about it below)
+- `gpu%`: GPU percentage (sim across cards)
+- `gpumem%`: GPU memory percentage (in percent of memory across all cards)
+- `gpukib`: GPU memory used in KiB (sum across cards)
+
+`gpumem%` vs `gpukib`:
+The difference is that on some cards some of the time it is possible to
+determine one of these but not the other, and vice versa. For example, on the
+NVIDIA cards we can read both quantities for running processes but only
+`gpukib` for some zombies. Since we can detect the total amount of memory here
+we could translate `gpukib` into `gpumem%`, though. On the other hand, on our
+AMD cards there is no support for detecting the absolute amount of memory used,
+nor the total amount of memory on the cards, only the percentage of gpu memory
+used. Rather than encoding the logic for dealing with this, it seemed better
+for the time being to report what we can report and let the analyzer sort it
+out.
+
+`gpus` are GPU devices:
+- If a process would use GPUs 1, 3, and 7: `"gpus={1, 3, 7}"`
+- If a process would use no or unknown GPUs: `gpus={}`
 
 
 ## Collect results with `sonar analyze` :construction:

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Here is an example output:
 ```console
 $ sonar ps
 
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=.vim-wrapped,cpu%=1.9,cpukib=7228,gpus={},gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=node,cpu%=1.8,cpukib=79332,gpus={},gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=slack,cpu%=0.7,cpukib=591720,gpus={},gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=X,cpu%=1.5,cpukib=224416,gpus={},gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=brave,cpu%=12.1,cpukib=3075300,gpus={},gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=alacritty,cpu%=1.2,cpukib=286196,gpus={},gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=sonar,cpu%=9,cpukib=372,gpus={},gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=.vim-wrapped,cpu%=1.9,cpukib=7228,gpus=none,gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=node,cpu%=1.8,cpukib=79332,gpus=none,gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=slack,cpu%=0.7,cpukib=591720,gpus=none,gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=X,cpu%=1.5,cpukib=224416,gpus=none,gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=brave,cpu%=12.1,cpukib=3075300,gpus=none,gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=alacritty,cpu%=1.2,cpukib=286196,gpus=none,gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=sonar,cpu%=9,cpukib=372,gpus=none,gpu%=0,gpumem%=0,gpukib=0
 ```
 
 The columns are:
@@ -103,12 +103,12 @@ The columns are:
 - `user` : username owning the process/command (it can also be "unknown" and "zombie")
 - `job`: job ID (positive integer; 0 if not applicable)
 - `cmd`: process/command
-- `cpu%`: CPU percentage (in percent of one core; as they come out of `ps`)
-- `cpukib`: CPU memory used in KiB
+- `cpu%`: CPU percentage (in percent of one core; as they come out of `ps`; this is not a sample but a running average)
+- `cpukib`: CPU memory used in KiB (this is a sample)
 - `gpus`: GPU devices (the card indices are 1-based; more about it below)
-- `gpu%`: GPU percentage (sim across cards)
-- `gpumem%`: GPU memory percentage (in percent of memory across all cards)
-- `gpukib`: GPU memory used in KiB (sum across cards)
+- `gpu%`: GPU percentage (sim across cards; this is a sample)
+- `gpumem%`: GPU memory percentage (in percent of memory across all cards; this is a sample)
+- `gpukib`: GPU memory used in KiB (sum across cards; this is a sample)
 
 `gpumem%` vs `gpukib`:
 The difference is that on some cards some of the time it is possible to
@@ -123,8 +123,9 @@ for the time being to report what we can report and let the analyzer sort it
 out.
 
 `gpus` are GPU devices:
-- If a process would use GPUs 1, 3, and 7: `"gpus={1, 3, 7}"`
-- If a process would use no or unknown GPUs: `gpus={}`
+- If a process would use GPUs 1, 3, and 7: `"gpus=1,3,7"`
+- If a process would use no GPUs: `gpus=none`
+- If a process uses unknown GPUs: `gpus=unknown`
 
 
 ## Collect results with `sonar analyze` :construction:

--- a/README.md
+++ b/README.md
@@ -86,13 +86,12 @@ Here is an example output:
 ```console
 $ sonar ps
 
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=.vim-wrapped,cpu%=1.9,cpukib=7228,gpus=none,gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=node,cpu%=1.8,cpukib=79332,gpus=none,gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=slack,cpu%=0.7,cpukib=591720,gpus=none,gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=X,cpu%=1.5,cpukib=224416,gpus=none,gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=brave,cpu%=12.1,cpukib=3075300,gpus=none,gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=alacritty,cpu%=1.2,cpukib=286196,gpus=none,gpu%=0,gpumem%=0,gpukib=0
-v=0.7.0,time=2023-07-29T17:45:37+02:00,host=somehost,cores=12,user=someone,job=0,cmd=sonar,cpu%=9,cpukib=372,gpus=none,gpu%=0,gpumem%=0,gpukib=0
+v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=fish,cpu%=2.1,cpukib=64400,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=138
+v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=sonar,cpu%=761,cpukib=372,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=137
+v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=brave,cpu%=14.6,cpukib=2907168,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=3532
+v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=alacritty,cpu%=0.8,cpukib=126700,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=51
+v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=pulseaudio,cpu%=0.7,cpukib=90640,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=399
+v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=slack,cpu%=3.9,cpukib=716924,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=266
 ```
 
 The columns are:
@@ -109,6 +108,7 @@ The columns are:
 - `gpu%`: GPU percentage (sim across cards; this is a sample)
 - `gpumem%`: GPU memory percentage (in percent of memory across all cards; this is a sample)
 - `gpukib`: GPU memory used in KiB (sum across cards; this is a sample)
+- `cputime_sec`: Accumulated CPU time that a process has used
 
 `gpumem%` vs `gpukib`:
 The difference is that on some cards some of the time it is possible to

--- a/src/amd.rs
+++ b/src/amd.rs
@@ -13,7 +13,6 @@
 /// Even though the output is presented in the same format as for NVIDIA, we only have partial stats
 /// about the usage of various processes on the various devices.  We divide the utilization of a
 /// device by the number of processes on the device.  This is approximate.
-
 use crate::command::{self, CmdError};
 use crate::nvidia;
 
@@ -31,7 +30,6 @@ use crate::util::map;
 pub fn get_amd_information(
     user_by_pid: &HashMap<usize, String>,
 ) -> Result<Vec<nvidia::Process>, String> {
-
     // I've not been able to combine the two invocations of rocm-smi yet; we have to run the command
     // twice.  Not a happy situation.
 
@@ -194,7 +192,8 @@ GPU  Temp (DieEdge)  AvgPwr  SCLK     MCLK    Fan     Perf  PwrCap  VRAM%  GPU%
 1    26.0c           3.0W    852Mhz   167Mhz  9.41%   auto  220.0W    5%   63%
 ================================================================================
 ",
-    ).unwrap();
+    )
+    .unwrap();
     assert!(xs.eq(&vec![(99.0, 57.0), (63.0, 5.0)]));
 }
 
@@ -248,7 +247,8 @@ PID 25774 is using 1 DRM device(s):
 0
 ================================================================================
 ",
-    ).unwrap();
+    )
+    .unwrap();
     assert!(xs.eq(&vec![(25774, vec![0])]));
     let xs = parse_showpidgpus_command(
         "
@@ -256,7 +256,8 @@ PID 25774 is using 1 DRM device(s):
 No KFD PIDs currently running
 ================================================================================
 ",
-    ).unwrap();
+    )
+    .unwrap();
     assert!(xs.eq(&vec![]));
 
     let xs = parse_showpidgpus_command(
@@ -268,7 +269,8 @@ PID 28154 is using 1 DRM device(s):
 0
 ================================================================================
 ",
-    ).unwrap();
+    )
+    .unwrap();
     assert!(xs.eq(&vec![(28156, vec![1]), (28154, vec![0])]));
     let xs = parse_showpidgpus_command(
         "
@@ -277,7 +279,8 @@ PID 29212 is using 2 DRM device(s):
 0 1
 ================================================================================
 ",
-    ).unwrap();
+    )
+    .unwrap();
     assert!(xs.eq(&vec![(29212, vec![0, 1])]));
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -54,7 +54,7 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
                 if !stderr.is_empty() {
                     stderr_result += &stderr;
                     break Some(CmdError::Failed(format_failure(
-                        &command,
+                        command,
                         &stdout_result,
                         &stderr_result,
                     )));
@@ -67,7 +67,7 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
             }
             Ok((_, _)) => {
                 break Some(CmdError::InternalError(format_failure(
-                    &command,
+                    command,
                     &stdout_result,
                     &stderr_result,
                 )))
@@ -77,14 +77,14 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
                     match p.terminate() {
                         Ok(_) => {
                             break Some(CmdError::Hung(format_failure(
-                                &command,
+                                command,
                                 &stdout_result,
                                 &stderr_result,
                             )))
                         }
                         Err(_) => {
                             break Some(CmdError::InternalError(format_failure(
-                                &command,
+                                command,
                                 &stdout_result,
                                 &stderr_result,
                             )))
@@ -92,7 +92,7 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
                     }
                 }
                 break Some(CmdError::InternalError(format_failure(
-                    &command,
+                    command,
                     &stdout_result,
                     &stderr_result,
                 )));
@@ -111,7 +111,7 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
         Ok(ExitStatus::Exited(126)) => {
             // 126 == "Command cannot execute"
             Err(CmdError::CouldNotStart(format_failure(
-                &command,
+                command,
                 &stdout_result,
                 &stderr_result,
             )))
@@ -119,7 +119,7 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
         Ok(ExitStatus::Exited(127)) => {
             // 127 == "Command not found"
             Err(CmdError::CouldNotStart(format_failure(
-                &command,
+                command,
                 &stdout_result,
                 &stderr_result,
             )))
@@ -127,18 +127,18 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
         Ok(ExitStatus::Signaled(15)) => {
             // Signal 15 == SIGTERM
             Err(CmdError::Hung(format_failure(
-                &command,
+                command,
                 &stdout_result,
                 &stderr_result,
             )))
         }
         Ok(_) => Err(CmdError::Failed(format_failure(
-            &command,
+            command,
             &stdout_result,
             &stderr_result,
         ))),
         Err(_) => Err(CmdError::InternalError(format_failure(
-            &command,
+            command,
             &stdout_result,
             &stderr_result,
         ))),

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -16,7 +16,7 @@ use crate::util::map;
 
 #[derive(PartialEq)]
 pub struct Process {
-    pub device: Option<usize>, // -1 for "unknown", otherwise 0..num_devices-1
+    pub device: Option<usize>, // Device ID
     pub pid: usize,            // Process ID
     pub user: String,          // User name, _zombie_PID for zombies
     pub gpu_pct: f64,          // Percent of GPU /for this sample/, 0.0 for zombies

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -6,7 +6,6 @@
 ///
 /// Crucially, the data are sampling data: they contain no (long) running averages, but are
 /// snapshots of the system at the time the sample is taken.
-
 use crate::command::{self, CmdError};
 use crate::util;
 
@@ -17,13 +16,13 @@ use crate::util::map;
 
 #[derive(PartialEq)]
 pub struct Process {
-    pub device: i32,         // -1 for "unknown", otherwise 0..num_devices-1
-    pub pid: usize,          // Process ID
-    pub user: String,        // User name, _zombie_PID for zombies
-    pub gpu_pct: f64,        // Percent of GPU /for this sample/, 0.0 for zombies
-    pub mem_pct: f64,        // Percent of memory /for this sample/, 0.0 for zombies
-    pub mem_size_kib: usize, // Memory use in KiB /for this sample/, _not_ zero for zombies
-    pub command: String,     // The command, _unknown_ for zombies, _noinfo_ if not known
+    pub device: Option<usize>, // -1 for "unknown", otherwise 0..num_devices-1
+    pub pid: usize,            // Process ID
+    pub user: String,          // User name, _zombie_PID for zombies
+    pub gpu_pct: f64,          // Percent of GPU /for this sample/, 0.0 for zombies
+    pub mem_pct: f64,          // Percent of memory /for this sample/, 0.0 for zombies
+    pub mem_size_kib: usize,   // Memory use in KiB /for this sample/, _not_ zero for zombies
+    pub command: String,       // The command, _unknown_ for zombies, _noinfo_ if not known
 }
 
 // Err(e) really means the command started running but failed, for the reason given.  If the
@@ -77,7 +76,7 @@ fn parse_pmon_output(raw_text: &str, user_by_pid: &HashMap<usize, String>) -> Ve
         .filter(|line| !line.starts_with('#'))
         .map(|line| {
             let (_start_indices, parts) = util::chunks(line);
-            let device = parts[0].parse::<i32>().unwrap();
+            let device = parts[0].parse::<usize>().unwrap();
             let pid = parts[1];
             let mem_size = parts[3].parse::<usize>().unwrap_or(0);
             let gpu_pct = parts[4].parse::<f64>().unwrap_or(0.0);
@@ -95,7 +94,7 @@ fn parse_pmon_output(raw_text: &str, user_by_pid: &HashMap<usize, String>) -> Ve
                 None => "_zombie_".to_owned() + pid_str,
             };
             Process {
-                device,
+                device: Some(device),
                 pid,
                 user,
                 gpu_pct,
@@ -130,7 +129,7 @@ fn parse_query_output(raw_text: &str, user_by_pid: &HashMap<usize, String>) -> V
         })
         .filter(|(pid, ..)| !user_by_pid.contains_key(pid))
         .map(|(pid, user, command, mem_size_kib)| Process {
-            device: !0,
+            device: None,
             pid,
             user,
             gpu_pct: 0.0,
@@ -158,16 +157,16 @@ pub fn parsed_pmon_output() -> Vec<Process> {
 # Idx          #   C/G     %     %     %     %   name
 # gpu        pid  type    fb    sm   mem   enc   dec   command
 # Idx          #   C/G    MB     %     %     %     %   name
-    0     447153     C  7669     -     -     -     -   python3.9      
-    0     447160     C 11057     -     -     -     -   python3.9      
-    0     506826     C 11057     -     -     -     -   python3.9      
-    0    1864615     C  1635    40     0     -     -   python         
-    1    1864615     C   535     -     -     -     -   python         
-    1    2233095     C 24395    84    23     -     -   python3        
-    2    1864615     C   535     -     -     -     -   python         
-    2    1448150     C  9383     -     -     -     -   python3        
-    3    1864615     C   535     -     -     -     -   python         
-    3    2233469     C 15771    90    23     -     -   python3        
+    0     447153     C  7669     -     -     -     -   python3.9
+    0     447160     C 11057     -     -     -     -   python3.9
+    0     506826     C 11057     -     -     -     -   python3.9
+    0    1864615     C  1635    40     0     -     -   python
+    1    1864615     C   535     -     -     -     -   python
+    1    2233095     C 24395    84    23     -     -   python3
+    2    1864615     C   535     -     -     -     -   python
+    2    1448150     C  9383     -     -     -     -   python3
+    3    1864615     C   535     -     -     -     -   python
+    3    2233469     C 15771    90    23     -     -   python3
 ";
     parse_pmon_output(text, &mkusers())
 }
@@ -188,16 +187,16 @@ macro_rules! proc(
 #[test]
 fn test_parse_pmon_output() {
     assert!(parsed_pmon_output().into_iter().eq(vec![
-        proc! { 0,  447153, "bob",             0.0,  0.0,  7669 * 1024, "python3.9" },
-        proc! { 0,  447160, "bob",             0.0,  0.0, 11057 * 1024, "python3.9" },
-        proc! { 0,  506826, "_zombie_506826",  0.0,  0.0, 11057 * 1024, "python3.9" },
-        proc! { 0, 1864615, "alice",          40.0,  0.0,  1635 * 1024, "python" },
-        proc! { 1, 1864615, "alice",           0.0,  0.0,   535 * 1024, "python" },
-        proc! { 1, 2233095, "charlie",        84.0, 23.0, 24395 * 1024, "python3" },
-        proc! { 2, 1864615, "alice",           0.0,  0.0,   535 * 1024, "python" },
-        proc! { 2, 1448150, "_zombie_1448150", 0.0,  0.0,  9383 * 1024, "python3"},
-        proc! { 3, 1864615, "alice",           0.0,  0.0,   535 * 1024, "python" },
-        proc! { 3, 2233469, "charlie",        90.0, 23.0, 15771 * 1024, "python3" }
+        proc! { Some(0),  447153, "bob",             0.0,  0.0,  7669 * 1024, "python3.9" },
+        proc! { Some(0),  447160, "bob",             0.0,  0.0, 11057 * 1024, "python3.9" },
+        proc! { Some(0),  506826, "_zombie_506826",  0.0,  0.0, 11057 * 1024, "python3.9" },
+        proc! { Some(0), 1864615, "alice",          40.0,  0.0,  1635 * 1024, "python" },
+        proc! { Some(1), 1864615, "alice",           0.0,  0.0,   535 * 1024, "python" },
+        proc! { Some(1), 2233095, "charlie",        84.0, 23.0, 24395 * 1024, "python3" },
+        proc! { Some(2), 1864615, "alice",           0.0,  0.0,   535 * 1024, "python" },
+        proc! { Some(2), 1448150, "_zombie_1448150", 0.0,  0.0,  9383 * 1024, "python3"},
+        proc! { Some(3), 1864615, "alice",           0.0,  0.0,   535 * 1024, "python" },
+        proc! { Some(3), 2233469, "charlie",        90.0, 23.0, 15771 * 1024, "python3" }
     ]))
 }
 
@@ -212,6 +211,6 @@ pub fn parsed_query_output() -> Vec<Process> {
 #[test]
 fn test_parse_query_output() {
     assert!(parsed_query_output().into_iter().eq(vec![
-        proc! { !0, 3079002, "_zombie_3079002", 0.0, 0.0, 2350 * 1024, "_unknown_" }
+        proc! { None, 3079002, "_zombie_3079002", 0.0, 0.0, 2350 * 1024, "_unknown_" }
     ]))
 }

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -1,17 +1,17 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
+extern crate log;
+extern crate num_cpus;
+
 use crate::amd;
 use crate::jobs;
 use crate::nvidia;
 use crate::process;
 use crate::util::{three_places, time_iso8601};
-use std::collections::{HashMap, HashSet};
-
-extern crate log;
-extern crate num_cpus;
 
 use csv::Writer;
+use std::collections::{HashMap, HashSet};
 use std::io;
 
 #[cfg(test)]
@@ -275,13 +275,17 @@ pub fn create_snapshot(
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
     for ((user, job_id, command), job_info) in processes_by_job_id {
-        // FIXME this does not print "none" or "unknown"
-        let gpus_comma_separated: String = job_info
+        // "unknown" is not implemented, see https://github.com/NordicHPC/sonar/issues/75
+        let mut gpus_comma_separated: String = job_info
             .gpu_cards
             .iter()
             .map(|&num| num.to_string())
             .collect::<Vec<String>>()
             .join(",");
+
+        if gpus_comma_separated.is_empty() {
+            gpus_comma_separated = "none".to_string();
+        }
 
         writer
             .write_record([

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -275,6 +275,14 @@ pub fn create_snapshot(
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
     for ((user, job_id, command), job_info) in processes_by_job_id {
+        // FIXME this does not print "none" or "unknown"
+        let gpus_comma_separated: String = job_info
+            .gpu_cards
+            .iter()
+            .map(|&num| num.to_string())
+            .collect::<Vec<String>>()
+            .join(",");
+
         writer
             .write_record([
                 &format!("v={VERSION}"),
@@ -286,7 +294,7 @@ pub fn create_snapshot(
                 &format!("cmd={command}"),
                 &format!("cpu%={}", three_places(job_info.cpu_percentage)),
                 &format!("cpukib={}", job_info.mem_size),
-                &format!("gpus={:?}", job_info.gpu_cards),
+                &format!("gpus={}", gpus_comma_separated),
                 &format!("gpu%={}", three_places(job_info.gpu_percentage)),
                 &format!("gpumem%={}", three_places(job_info.gpu_mem_percentage)),
                 &format!("gpukib={}", job_info.gpu_mem_size),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,19 @@
 use chrono::prelude::Local;
 
+// Populate a HashSet.
+#[cfg(test)]
+macro_rules! set(
+    { $($key:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashSet::new();
+            $(
+                m.insert($key);
+            )+
+            m
+        }
+     };
+);
+
 // Populate a HashMap.
 #[cfg(test)]
 macro_rules! map(
@@ -16,6 +30,9 @@ macro_rules! map(
 
 #[cfg(test)]
 pub(crate) use map;
+
+#[cfg(test)]
+pub(crate) use set;
 
 // Get current time as an ISO time stamp.
 pub fn time_iso8601() -> String {


### PR DESCRIPTION
Summary:
- changes output format (which is explained in README.md)
- bumps version to 0.7.0

Please see the change in README.md for how the columns are defined. @lars-t-hansen can you please browse through this change carefully?

I am unsure about the `gpus` part.
- If a process would use GPUs 1, 3, and 7: `"gpus={1, 3, 7}"`
- If a process would use no or unknown GPUs: `gpus={}`

Do we want to distinguish no GPUs and unknown GPUs? If yes, how?
