### PR TITLE
Better error reporting.  Fixes #52

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "clap",
  "csv",
  "hostname",
+ "log",
  "num_cpus",
  "subprocess",
  "wait-timeout",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +196,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +260,12 @@ dependencies = [
  "match_cfg",
  "winapi",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -374,6 +402,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
 name = "rustix"
 version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +463,7 @@ dependencies = [
  "chrono",
  "clap",
  "csv",
+ "env_logger",
  "hostname",
  "log",
  "num_cpus",
@@ -438,6 +496,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -547,6 +614,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ num_cpus = "1.0"
 clap = { version = "4.3", features = ["derive"] }
 csv = "1.2"
 log = "0.4.19"
+env_logger = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ hostname = "0.3"
 num_cpus = "1.0"
 clap = { version = "4.3", features = ["derive"] }
 csv = "1.2"
+log = "0.4.19"

--- a/src/amd.rs
+++ b/src/amd.rs
@@ -46,7 +46,7 @@ pub fn get_amd_information(
                 Err(e) => Err(format!("{:?}", e)),
             }
         }
-        Err(CmdError::CouldNotStart) => Ok(vec![]),
+        Err(CmdError::CouldNotStart(_)) => Ok(vec![]),
         Err(e) => Err(format!("{:?}", e)),
     }
 }

--- a/src/amd.rs
+++ b/src/amd.rs
@@ -130,7 +130,7 @@ PID 28154 is using 1 DRM device(s):
     let users = map! {
     28156 => "bob".to_string()
     };
-    let zs = extract_amd_information(concise, pidgpu, &users);
+    let zs = extract_amd_information(concise, pidgpu, &users).unwrap();
     assert!(zs.eq(&vec![
         proc! { 0, 28154, "_zombie_28154", 99.0/2.0, 57.0/2.0 },
         proc! { 0, 28156, "bob", 99.0/2.0, 57.0/2.0 },
@@ -194,7 +194,7 @@ GPU  Temp (DieEdge)  AvgPwr  SCLK     MCLK    Fan     Perf  PwrCap  VRAM%  GPU%
 1    26.0c           3.0W    852Mhz   167Mhz  9.41%   auto  220.0W    5%   63%    
 ================================================================================
 ",
-    );
+    ).unwrap();
     assert!(xs.eq(&vec![(99.0, 57.0), (63.0, 5.0)]));
 }
 
@@ -248,7 +248,7 @@ PID 25774 is using 1 DRM device(s):
 0 
 ================================================================================
 ",
-    );
+    ).unwrap();
     assert!(xs.eq(&vec![(25774, vec![0])]));
     let xs = parse_showpidgpus_command(
         "
@@ -256,7 +256,7 @@ PID 25774 is using 1 DRM device(s):
 No KFD PIDs currently running
 ================================================================================
 ",
-    );
+    ).unwrap();
     assert!(xs.eq(&vec![]));
 
     let xs = parse_showpidgpus_command(
@@ -268,7 +268,7 @@ PID 28154 is using 1 DRM device(s):
 0 
 ================================================================================
 ",
-    );
+    ).unwrap();
     assert!(xs.eq(&vec![(28156, vec![1]), (28154, vec![0])]));
     let xs = parse_showpidgpus_command(
         "
@@ -277,7 +277,7 @@ PID 29212 is using 2 DRM device(s):
 0 1 
 ================================================================================
 ",
-    );
+    ).unwrap();
     assert!(xs.eq(&vec![(29212, vec![0, 1])]));
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -92,7 +92,9 @@ pub fn safe_command(command: &str, timeout_seconds: u64) -> Result<String, CmdEr
             // Signal 15 == SIGTERM
             Err(CmdError::Hung(command.to_string()))
         }
-        Ok(_) => Err(CmdError::Failed(command.to_string())),
+        Ok(_) => {
+            Err(CmdError::Failed(command.to_string()))
+        }
         Err(_) => Err(CmdError::InternalError(command.to_string())),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+extern crate env_logger;
+
 use clap::{Parser, Subcommand};
 
 mod amd;
@@ -33,6 +35,8 @@ enum Commands {
 }
 
 fn main() {
+    env_logger::init();
+
     let cli = Cli::parse();
 
     match &cli.command {

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -9,9 +9,11 @@
 
 use crate::command::{self, CmdError};
 use crate::util;
+
+use std::collections::HashMap;
+
 #[cfg(test)]
 use crate::util::map;
-use std::collections::HashMap;
 
 #[derive(PartialEq)]
 pub struct Process {
@@ -29,7 +31,7 @@ pub struct Process {
 
 pub fn get_nvidia_information(
     user_by_pid: &HashMap<usize, String>,
-) -> Result<Vec<Process>, CmdError> {
+) -> Result<Vec<Process>, String> {
     match command::safe_command(NVIDIA_PMON_COMMAND, TIMEOUT_SECONDS) {
         Ok(pmon_raw_text) => {
             let mut processes = parse_pmon_output(&pmon_raw_text, user_by_pid);
@@ -38,11 +40,11 @@ pub fn get_nvidia_information(
                     processes.append(&mut parse_query_output(&query_raw_text, user_by_pid));
                     Ok(processes)
                 }
-                Err(e) => Err(e),
+                Err(e) => Err(format!("{:?}", e)),
             }
         }
         Err(CmdError::CouldNotStart) => Ok(vec![]),
-        Err(e) => Err(e),
+        Err(e) => Err(format!("{:?}", e)),
     }
 }
 

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -43,7 +43,7 @@ pub fn get_nvidia_information(
                 Err(e) => Err(format!("{:?}", e)),
             }
         }
-        Err(CmdError::CouldNotStart) => Ok(vec![]),
+        Err(CmdError::CouldNotStart(_)) => Ok(vec![]),
         Err(e) => Err(format!("{:?}", e)),
     }
 }

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -173,7 +173,7 @@ fn add_gpu_info(
             }
         }
         Err(e) => {
-            log::error!("GPU process listing failed:\n{}", e);
+            log::error!("GPU process listing failed: {}", e);
         }
     }
 }

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -6,12 +6,16 @@ use crate::jobs;
 use crate::nvidia;
 use crate::process;
 use crate::util::{three_places, time_iso8601};
-use std::collections::HashMap;
+
 extern crate num_cpus;
+extern crate log;
+
+use csv::Writer;
+use std::collections::HashMap;
+use std::io;
+
 #[cfg(test)]
 use crate::util::map;
-use csv::Writer;
-use std::io;
 
 struct JobInfo {
     cpu_percentage: f64,
@@ -169,7 +173,7 @@ fn add_gpu_info(
             }
         }
         Err(e) => {
-            log_cmderror(&format!("GPU process listing failed:\n{}", e));
+            log::error!("GPU process listing failed:\n{}", e);
         }
     }
 }
@@ -220,7 +224,7 @@ pub fn create_snapshot(
 
     match process::get_process_information(jobs) {
         Err(e) => {
-            log_cmderror(&format!("CPU process listing failed: {:?}", e));
+            log::error!("CPU process listing failed: {:?}", e);
             return;
         }
         Ok(ps_output) => {
@@ -283,9 +287,4 @@ pub fn create_snapshot(
     }
 
     writer.flush().unwrap();
-}
-
-fn log_cmderror(msg: &str) {
-    // TODO (issue 52): Implement some sensible logging maybe
-    eprintln!("SONAR ERROR: {:?}", msg);
 }

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -219,8 +219,8 @@ pub fn create_snapshot(
     let mut user_by_pid: HashMap<usize, String> = HashMap::new();
 
     match process::get_process_information(jobs) {
-        Err(_) => {
-            log_cmderror("CPU process listing failed");
+        Err(e) => {
+            log_cmderror(&format!("CPU process listing failed: {:?}", e));
             return;
         }
         Ok(ps_output) => {

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::amd;
-use crate::command::CmdError;
 use crate::jobs;
 use crate::nvidia;
 use crate::process;
@@ -146,7 +145,7 @@ fn extract_nvidia_processes(
 
 fn add_gpu_info(
     processes_by_slurm_job_id: &mut HashMap<(String, usize, String), JobInfo>,
-    gpu_output: Result<Vec<nvidia::Process>, CmdError>,
+    gpu_output: Result<Vec<nvidia::Process>, String>,
 ) {
     match gpu_output {
         Ok(gpu_output) => {
@@ -169,8 +168,8 @@ fn add_gpu_info(
                 );
             }
         }
-        Err(_) => {
-            log_cmderror("GPU process listing failed");
+        Err(e) => {
+            log_cmderror(&format!("GPU process listing failed:\n{}", e));
         }
     }
 }


### PR DESCRIPTION
Basically:

- propagate errors from lower layers (haven't done anything about the slurm component yet) as meaningful strings
- carry the failed command and its output (if any) with the CmdError
- use the standard logger to log these errors

This change pulls in a fair amount of code, I think chiefly through the env_logger library used to initialize logging.

For my purposes, this logging (to stderr) is roughly what I want, since cron captures the output and emails it to me.  But it may get further tweaking down the line.