### PR TITLE
Revamp ps.  Fixes #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@
 # sonar
 
 Tool to profile usage of HPC resources by regularly probing processes using
-`ps`.
+`ps` and other tools.
 
-All it really does is to run
-`ps -e --no-header -o pid,user:22,pcpu,pmem,size,comm`
-under the hood, and then filters and groups
-the output and prints it to stdout, comma-separated.
+All it really does is to run `ps` and other diagnostic programs under the hood,
+and then filters and groups the output and prints it to stdout, comma-separated.
 
 ![image of a fish swarm](img/sonar-small.png)
 
@@ -100,7 +98,7 @@ The columns are:
 - `host`: host name (FQDN)
 - `cores`: number of cores on this node (positive integer)
 - `user` : username owning the process/command (it can also be "unknown" and "zombie")
-- `job`: job ID (positive integer; 0 if not applicable)
+- `job`: job ID (positive integer; 0 if not applicable, see below)
 - `cmd`: process/command
 - `cpu%`: CPU percentage (in percent of one core; as they come out of `ps`; this is not a sample but a running average)
 - `cpukib`: CPU memory used in KiB (this is a sample)
@@ -109,6 +107,14 @@ The columns are:
 - `gpumem%`: GPU memory percentage (in percent of memory across all cards; this is a sample)
 - `gpukib`: GPU memory used in KiB (sum across cards; this is a sample)
 - `cputime_sec`: Accumulated CPU time that a process has used
+
+`job`:
+There may be multiple records for the same job, one for each process in the job
+(subject to filtering).  Processes in the same job are not merged in the output
+even if they have the same command name (this is a change from earlier code).
+NOTE CAREFULLY that if the job ID is 0 then the process record is for a
+unique job with unknown job ID.  Multiple records with the job ID 0 should never
+be merged into a single job by the consumer.
 
 `gpumem%` vs `gpukib`:
 The difference is that on some cards some of the time it is possible to
@@ -139,7 +145,7 @@ folder.
 
 - [Radovan Bast](https://bast.fr)
 - Mathias Bockwoldt
-- Lars T. Hansen
+- [Lars T. Hansen](https://github.com/lars-t-hansen)
 - Henrik Rojas Nagel
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,21 @@ struct Cli {
 enum Commands {
     /// Take a snapshot of the currently running processes
     PS {
+        /// Do not print records for jobs that have not on average used more than this percentage of CPU
         #[arg(long, default_value_t = 0.5)]
         cpu_cutoff_percent: f64,
+
+        /// Do not print records for jobs that do not presently use more than this percentage of real memory
         #[arg(long, default_value_t = 5.0)]
         mem_cutoff_percent: f64,
+
+        /// Synthesize a job ID from the process tree in which a process finds itself
         #[arg(long, default_value_t = false)]
         batchless: bool,
+
+        /// Merge process records that have the same job ID and command name
+        #[arg(long, default_value_t = false)]
+        rollup: bool,
     },
     /// Not yet implemented
     Analyze {},
@@ -43,14 +52,15 @@ fn main() {
         Commands::PS {
             cpu_cutoff_percent,
             mem_cutoff_percent,
+            rollup,
             batchless,
         } => {
             if *batchless {
                 let mut jm = batchless::BatchlessJobManager::new();
-                ps::create_snapshot(&mut jm, *cpu_cutoff_percent, *mem_cutoff_percent);
+                ps::create_snapshot(&mut jm, *rollup, *cpu_cutoff_percent, *mem_cutoff_percent);
             } else {
                 let mut jm = slurm::SlurmJobManager {};
-                ps::create_snapshot(&mut jm, *cpu_cutoff_percent, *mem_cutoff_percent);
+                ps::create_snapshot(&mut jm, *rollup, *cpu_cutoff_percent, *mem_cutoff_percent);
             }
         }
         Commands::Analyze {} => {

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,4 @@
-// Run "ps" and return a vector of structures with all the information we need.
+/// Collect CPU process information without GPU information.
 
 use crate::command::{self, CmdError};
 use crate::jobs;
@@ -16,6 +16,9 @@ pub struct Process {
     pub ppid: usize,    // 0 if !jobs.need_process_tree()
     pub session: usize, // 0 if !jobs.need_process_tree()
 }
+
+/// Run "ps" and return a vector of structures with all the information we need.
+/// In the returned vector, pids uniquely tag the records.
 
 pub fn get_process_information(jobs: &mut dyn jobs::JobManager) -> Result<Vec<Process>, CmdError> {
     let need_process_tree = jobs.need_process_tree();

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -14,239 +14,90 @@ use csv::Writer;
 use std::collections::{HashMap, HashSet};
 use std::io;
 
-#[cfg(test)]
-use crate::util::{map, set};
+type GpuSet = HashSet<usize>;
 
-struct JobInfo {
-    cpu_percentage: f64,
-    cputime_sec: usize,
-    mem_size: usize,
-    gpu_cards: HashSet<usize>,
-    gpu_percentage: f64,
-    gpu_mem_percentage: f64,
-    gpu_mem_size: usize,
-}
-
-fn add_job_info(
-    processes_by_job_id: &mut HashMap<(String, usize, String), JobInfo>,
-    user: String,
-    job_id: usize,
-    command: String,
-    cpu_percentage: f64,
-    cputime_sec: usize,
-    mem_size: usize,
-    gpu_cards: HashSet<usize>,
-    gpu_percentage: f64,
-    gpu_mem_percentage: f64,
-    gpu_mem_size: usize,
-) {
-    processes_by_job_id
-        .entry((user, job_id, command))
-        .and_modify(|e| {
-            e.cpu_percentage += cpu_percentage;
-            e.cputime_sec += cputime_sec;
-            e.mem_size += mem_size;
-            e.gpu_cards.extend(&gpu_cards);
-            e.gpu_percentage += gpu_percentage;
-            e.gpu_mem_percentage += gpu_mem_percentage;
-            e.gpu_mem_size += gpu_mem_size;
-        })
-        .or_insert(JobInfo {
-            cpu_percentage,
-            cputime_sec,
-            mem_size,
-            gpu_cards,
-            gpu_percentage,
-            gpu_mem_percentage,
-            gpu_mem_size,
-        });
-}
-
-type Pid = usize;
-
-#[derive(PartialEq)]
-struct PsInfo {
-    user: String,
-    command: String,
-    cpu_pct: f64,
-    cputime_sec: usize,
-    mem_pct: f64,
-    mem_size_kib: usize
-}
-
-impl PsInfo {
-    fn new(user: &str, command: &str, cpu_pct: f64, cputime_sec: usize, mem_pct: f64, mem_size_kib: usize) -> PsInfo {
-        PsInfo {
-            user: user.to_string(),
-            command: command.to_string(),
-            cpu_pct,
-            cputime_sec,
-            mem_pct,
-            mem_size_kib
-        }
-    }
-}
-
-fn extract_ps_info(processes: &[process::Process]) -> HashMap<Pid, PsInfo> {
-    processes
-        .iter()
-        .map(
-            |process::Process {
-                 user,
-                 pid,
-                 command,
-                 cpu_pct,
-                 cputime_sec,
-                 mem_pct,
-                 mem_size_kib,
-                 ..
-             }| (*pid, PsInfo::new(&user, &command, *cpu_pct, *cputime_sec, *mem_pct, *mem_size_kib)),
-        )
-        .fold(HashMap::new(), |mut acc, (key, value)| {
-            if let Some(ps_info) = acc.get_mut(&key) {
-                ps_info.cpu_pct += value.cpu_pct;
-                ps_info.cputime_sec += value.cputime_sec;
-                ps_info.mem_pct += value.mem_pct;
-                ps_info.mem_size_kib += value.mem_size_kib;
-            } else {
-                acc.insert(key, value);
-            }
-            acc
-        })
-}
-
-#[test]
-fn test_extract_ps_info() {
-    let ps_output = process::parsed_test_output();
-    let ps_info = extract_ps_info(&ps_output);
-
-    assert!(
-        ps_info
-            == map! {
-                2022 => PsInfo::new("bob", "slack", 10.0, 60+28, 20.0, 553348),
-                42178 => PsInfo::new("bob", "chromium", 20.0, 60+29+60+30, 30.0, 358884),
-                42189 => PsInfo::new("alice", "slack", 10.0, 60+31, 5.0, 5528),
-                42191 => PsInfo::new("bob", "someapp", 10.0, 60+32, 5.0, 5552),
-                42213 => PsInfo::new("alice", "some app", 20.0, 60+33+60+34, 10.0, 484268)
-            }
-    );
-}
-
-#[derive(PartialEq)]
-struct GpuInfo {
-    user: String,
-    command: String,
-    gpus: HashSet<usize>,
-    gpu_pct: f64,
-    gpumem_pct: f64,
-    gpumem_size_kib: usize,
-}
-
-impl GpuInfo {
-    fn new(user: &str, command: &str, gpus: HashSet<usize>, gpu_pct: f64, gpumem_pct: f64, gpumem_size_kib: usize) -> GpuInfo {
-        GpuInfo {
-            user: user.to_string(),
-            command: command.to_string(),
-            gpus,
-            gpu_pct,
-            gpumem_pct,
-            gpumem_size_kib
-        }
-    }
-}
-
-fn extract_gpu_info(processes: &[nvidia::Process]) -> HashMap<Pid, GpuInfo> {
-    processes
-        .iter()
-        .map(
-            |nvidia::Process {
-                 device,
-                 pid,
-                 user,
-                 gpu_pct,
-                 mem_pct,
-                 mem_size_kib,
-                 command,
-             }| (*pid, GpuInfo::new(&user, &command, make_gpuset(*device), *gpu_pct, *mem_pct, *mem_size_kib)))
-        .fold(HashMap::new(), |mut acc, (key, value)| {
-            if let Some(gpu_info) = acc.get_mut(&key) {
-                gpu_info.gpus.extend(value.gpus);
-                gpu_info.gpu_pct += value.gpu_pct;
-                gpu_info.gpumem_pct += value.gpumem_pct;
-                gpu_info.gpumem_size_kib += value.gpumem_size_kib;
-            } else {
-                acc.insert(key, value);
-            }
-            acc
-        })
-}
-
-fn make_gpuset(maybe_device: Option<usize>) -> HashSet<usize> {
-    let mut gpus = HashSet::new();
+fn make_gpuset(maybe_device: Option<usize>) -> GpuSet {
+    let mut gpus = GpuSet::new();
     if let Some(dev) = maybe_device {
         gpus.insert(dev);
     }
     gpus
 }
 
-fn add_gpu_info(
-    processes_by_slurm_job_id: &mut HashMap<(String, usize, String), JobInfo>,
-    gpu_output: Result<Vec<nvidia::Process>, String>,
-) {
-    match gpu_output {
-        Ok(gpu_output) => {
-            for (pid, gpu_info) in extract_gpu_info(&gpu_output) {
-                add_job_info(
-                    processes_by_slurm_job_id,
-                    gpu_info.user,
-                    pid,
-                    gpu_info.command,
-                    0.0,
-                    0,
-                    0,
-                    gpu_info.gpus,
-                    gpu_info.gpu_pct,
-                    gpu_info.gpumem_pct,
-                    gpu_info.gpumem_size_kib,
-                );
-            }
-        }
-        Err(e) => {
-            log::error!("GPU process listing failed: {}", e);
-        }
-    }
+type Pid = usize;
+type JobID = usize;
+
+// ProcInfo holds per-process information gathered from multiple sources and tagged with a job ID.
+// No processes are merged!  The job ID "0" means "unique job with no job ID".  That is, no consumer
+// of this data, internal or external to the program, may treat processes with job ID "0" as part of
+// the same job.
+
+struct ProcInfo<'a> {
+    user: &'a str,
+    command: &'a str,
+    _pid: Pid,
+    job_id: usize,
+    cpu_percentage: f64,
+    cputime_sec: usize,
+    mem_percentage: f64,
+    mem_size_kib: usize,
+    gpu_cards: GpuSet,
+    gpu_percentage: f64,
+    gpu_mem_percentage: f64,
+    gpu_mem_size_kib: usize,
 }
 
-#[test]
-fn test_extract_nvidia_pmon_processes() {
-    let ps_output = nvidia::parsed_pmon_output();
-    let gpu_info = extract_gpu_info(&ps_output);
+type ProcTable<'a> = HashMap<Pid, ProcInfo<'a>>;
 
-    assert!(
-        gpu_info
-            == map! {
-                447153 => GpuInfo::new("bob", "python3.9", set!{0}, 0.0, 0.0, 7669*1024),
-                447160 => GpuInfo::new("bob", "python3.9", set!{0}, 0.0, 0.0, 11057*1024),
-                506826 => GpuInfo::new("_zombie_506826", "python3.9", set!{0}, 0.0, 0.0, 11057*1024),
-                1864615 => GpuInfo::new("alice", "python", set!{0, 1, 2, 3}, 40.0, 0.0, (1635+535+535+535)*1024),
-                2233095 => GpuInfo::new("charlie", "python3", set!{1}, 84.0, 23.0, 24395*1024),
-                1448150 => GpuInfo::new("_zombie_1448150", "python3", set!{2}, 0.0, 0.0, 9383*1024),
-                2233469 => GpuInfo::new("charlie", "python3", set!{3}, 90.0, 23.0, 15771*1024)
-            }
-    );
-}
+// Add information about the process to the table `proc_by_pid`.  Here, `lookup_job_by_pid`, `user`,
+// `command`, and `pid` must be provided while the subsequent fields are all optional and must be
+// zero / empty if there's no information.
 
-#[test]
-fn test_extract_nvidia_query_processes() {
-    let ps_output = nvidia::parsed_query_output();
-    let gpu_info = extract_gpu_info(&ps_output);
-
-    assert!(
-        gpu_info
-            == map! {
-                3079002 => GpuInfo::new("_zombie_3079002", "_unknown_", HashSet::new(), 0.0, 0.0, 2350*1024)
-            }
-    );
+fn add_proc_info<'a, F>(
+    proc_by_pid: &mut ProcTable<'a>,
+    lookup_job_by_pid: &mut F,
+    user: &'a str,
+    command: &'a str,
+    pid: Pid,
+    cpu_percentage: f64,
+    cputime_sec: usize,
+    mem_percentage: f64,
+    mem_size_kib: usize,
+    gpu_cards: &GpuSet,
+    gpu_percentage: f64,
+    gpu_mem_percentage: f64,
+    gpu_mem_size_kib: usize,
+)
+where
+    F: FnMut(Pid) -> JobID
+{
+    proc_by_pid
+        .entry(pid)
+        .and_modify(|e| {
+            // Already has user, command, pid, job_id
+            e.cpu_percentage += cpu_percentage;
+            e.cputime_sec += cputime_sec;
+            e.mem_percentage += mem_percentage;
+            e.mem_size_kib += mem_size_kib;
+            e.gpu_cards.extend(gpu_cards);
+            e.gpu_percentage += gpu_percentage;
+            e.gpu_mem_percentage += gpu_mem_percentage;
+            e.gpu_mem_size_kib += gpu_mem_size_kib;
+        })
+        .or_insert(ProcInfo {
+            user,
+            command,
+            _pid: pid,
+            job_id: lookup_job_by_pid(pid),
+            cpu_percentage,
+            cputime_sec,
+            mem_percentage,
+            mem_size_kib,
+            gpu_cards: gpu_cards.clone(),
+            gpu_percentage,
+            gpu_mem_percentage,
+            gpu_mem_size_kib,
+        });
 }
 
 pub fn create_snapshot(
@@ -257,56 +108,103 @@ pub fn create_snapshot(
     let timestamp = time_iso8601();
     let hostname = hostname::get().unwrap().into_string().unwrap();
     let num_cores = num_cpus::get();
+    let no_gpus = make_gpuset(None);
+    let mut proc_by_pid = ProcTable::new();
 
-    let mut processes_by_job_id: HashMap<(String, usize, String), JobInfo> = HashMap::new();
+    let ps_probe = process::get_process_information(jobs);
+    if let Err(e) = ps_probe {
+        // This is a hard error, we need this information for everything.
+        log::error!("CPU process listing failed: {:?}", e);
+        return;
+    }
+    let ps_output = &ps_probe.unwrap();
+
+    // The table of users is needed to get GPU information
     let mut user_by_pid: HashMap<usize, String> = HashMap::new();
+    for proc in ps_output {
+        user_by_pid.insert(proc.pid, proc.user.clone());
+    }
 
-    match process::get_process_information(jobs) {
+    let mut lookup_job_by_pid = |pid: Pid| {
+        jobs.job_id_from_pid(pid, ps_output)
+    };
+
+    for proc in ps_output {
+        add_proc_info(&mut proc_by_pid,
+                      &mut lookup_job_by_pid,
+                      &proc.user,
+                      &proc.command,
+                      proc.pid,
+                      proc.cpu_pct,
+                      proc.cputime_sec,
+                      proc.mem_pct,
+                      proc.mem_size_kib,
+                      &no_gpus, // gpu_cards
+                      0.0,      // gpu_percentage
+                      0.0,      // gpu_mem_percentage
+                      0);       // gpu_mem_size_kib
+    }
+
+    let nvidia_probe = nvidia::get_nvidia_information(&user_by_pid);
+    match nvidia_probe {
         Err(e) => {
-            log::error!("CPU process listing failed: {:?}", e);
-            return;
+            // This is a soft error.
+            log::error!("GPU (Nvidia) process listing failed: {:?}", e);
         }
-        Ok(ps_output) => {
-            for (pid, ps_info) in extract_ps_info(&ps_output)
-            {
-                user_by_pid.insert(pid, ps_info.user.clone());
-
-                if (ps_info.cpu_pct >= cpu_cutoff_percent) || (ps_info.mem_pct >= mem_cutoff_percent)
-                {
-                    add_job_info(
-                        &mut processes_by_job_id,
-                        ps_info.user,
-                        jobs.job_id_from_pid(pid, &ps_output),
-                        ps_info.command,
-                        ps_info.cpu_pct,
-                        ps_info.cputime_sec,
-                        ps_info.mem_size_kib,
-                        HashSet::new(),
-                        0.0,
-                        0.0,
-                        0,
-                    );
-                }
+        Ok(ref nvidia_output) => {
+            for proc in nvidia_output {
+                add_proc_info(&mut proc_by_pid,
+                              &mut lookup_job_by_pid,
+                              &proc.user,
+                              &proc.command,
+                              proc.pid,
+                              0.0, // cpu_percentage
+                              0,   // cputime_sec
+                              0.0, // mem_percentage
+                              0,   // mem_size_kib
+                              &make_gpuset(proc.device),
+                              proc.gpu_pct,
+                              proc.mem_pct,
+                              proc.mem_size_kib);
             }
         }
     }
 
-    add_gpu_info(
-        &mut processes_by_job_id,
-        nvidia::get_nvidia_information(&user_by_pid),
-    );
-    add_gpu_info(
-        &mut processes_by_job_id,
-        amd::get_amd_information(&user_by_pid),
-    );
+    let amd_probe = amd::get_amd_information(&user_by_pid);
+    match amd_probe {
+        Err(e) => {
+            // This is a soft error.
+            log::error!("GPU (Nvidia) process listing failed: {:?}", e);
+        }
+        Ok(ref amd_output) => {
+            for proc in amd_output {
+                add_proc_info(&mut proc_by_pid,
+                              &mut lookup_job_by_pid,
+                              &proc.user,
+                              &proc.command,
+                              proc.pid,
+                              0.0, // cpu_percentage
+                              0,   // cputime_sec
+                              0.0, // mem_percentage
+                              0,   // mem_size_kib
+                              &make_gpuset(proc.device),
+                              proc.gpu_pct,
+                              proc.mem_pct,
+                              proc.mem_size_kib);
+            }
+        }
+    }
 
     let mut writer = Writer::from_writer(io::stdout());
 
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-    for ((user, job_id, command), job_info) in processes_by_job_id {
+    for (_, proc_info) in proc_by_pid {
+        if (proc_info.cpu_percentage < cpu_cutoff_percent) && (proc_info.mem_percentage < mem_cutoff_percent) {
+            continue;
+        }
         // "unknown" is not implemented, see https://github.com/NordicHPC/sonar/issues/75
-        let mut gpus_comma_separated: String = job_info
+        let mut gpus_comma_separated: String = proc_info
             .gpu_cards
             .iter()
             .map(|&num| num.to_string())
@@ -323,16 +221,16 @@ pub fn create_snapshot(
                 &format!("time={timestamp}"),
                 &format!("host={hostname}"),
                 &format!("cores={num_cores}"),
-                &format!("user={user}"),
-                &format!("job={job_id}"),
-                &format!("cmd={command}"),
-                &format!("cpu%={}", three_places(job_info.cpu_percentage)),
-                &format!("cpukib={}", job_info.mem_size),
+                &format!("user={}", proc_info.user),
+                &format!("job={}", proc_info.job_id),
+                &format!("cmd={}", proc_info.command),
+                &format!("cpu%={}", three_places(proc_info.cpu_percentage)),
+                &format!("cpukib={}", proc_info.mem_size_kib),
                 &format!("gpus={}", gpus_comma_separated),
-                &format!("gpu%={}", three_places(job_info.gpu_percentage)),
-                &format!("gpumem%={}", three_places(job_info.gpu_mem_percentage)),
-                &format!("gpukib={}", job_info.gpu_mem_size),
-                &format!("cputime_sec={}", job_info.cputime_sec),
+                &format!("gpu%={}", three_places(proc_info.gpu_percentage)),
+                &format!("gpumem%={}", three_places(proc_info.gpu_mem_percentage)),
+                &format!("gpukib={}", proc_info.gpu_mem_size_kib),
+                &format!("cputime_sec={}", proc_info.cputime_sec),
             ])
             .unwrap();
     }

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -32,10 +32,12 @@ type JobID = usize;
 // of this data, internal or external to the program, may treat processes with job ID "0" as part of
 // the same job.
 
+#[derive(Clone)]
 struct ProcInfo<'a> {
     user: &'a str,
     command: &'a str,
     _pid: Pid,
+    rolledup: usize,
     job_id: usize,
     cpu_percentage: f64,
     cputime_sec: usize,
@@ -88,6 +90,7 @@ where
             user,
             command,
             _pid: pid,
+            rolledup: 0,
             job_id: lookup_job_by_pid(pid),
             cpu_percentage,
             cputime_sec,
@@ -102,12 +105,10 @@ where
 
 pub fn create_snapshot(
     jobs: &mut dyn jobs::JobManager,
+    rollup_by_jobid_and_command: bool,
     cpu_cutoff_percent: f64,
     mem_cutoff_percent: f64,
 ) {
-    let timestamp = time_iso8601();
-    let hostname = hostname::get().unwrap().into_string().unwrap();
-    let num_cores = num_cpus::get();
     let no_gpus = make_gpuset(None);
     let mut proc_by_pid = ProcTable::new();
 
@@ -197,43 +198,123 @@ pub fn create_snapshot(
 
     let mut writer = Writer::from_writer(io::stdout());
 
+    let timestamp = time_iso8601();
+    let hostname = hostname::get().unwrap().into_string().unwrap();
+    let num_cores = num_cpus::get();
     const VERSION: &str = env!("CARGO_PKG_VERSION");
+    let print_params = PrintParameters {
+        hostname: &hostname,
+        timestamp: &timestamp,
+        num_cores,
+        version: VERSION,
+        cpu_cutoff_percent,
+        mem_cutoff_percent
+    };
 
-    for (_, proc_info) in proc_by_pid {
-        if (proc_info.cpu_percentage < cpu_cutoff_percent) && (proc_info.mem_percentage < mem_cutoff_percent) {
-            continue;
+    if rollup_by_jobid_and_command {
+        // This is a little complicated because jobs with job_id 0 cannot be rolled up.
+        //
+        // - There is an array `rolledup` of ProcInfo nodes that represent rolled-up data
+        //
+        // - When the job ID of a job in `proc_by_pid` is zero, the entry in `rolledup` is a copy of
+        //   that job; these jobs cannot be rolled up (this is why it's complicated)
+        //
+        // - Otherwise, the entry in `rolledup` represent rolled-up information for a (job, command) pair
+        //
+        // - There is a hash table `index` that maps the (job, command) pair to the entry in `rolledup`,
+        //   if any
+        //
+        // - When we're done rolling up, we print the `rolledup` table.
+        //
+        // Filtering is performed after rolling up, so if a rolled-up job has a bunch of dinky
+        // processes that together push it over the filtering limit then it will be printed.  This
+        // is probably the right thing.
+
+        let mut rolledup = vec![];
+        let mut index = HashMap::<(JobID, &str), usize>::new();
+        for (_, proc_info) in &proc_by_pid {
+            if proc_info.job_id == 0 {
+                rolledup.push(proc_info.clone());
+            } else {
+                let key = (proc_info.job_id, proc_info.command);
+                if let Some(x) = index.get(&key) {
+                    let p = &mut rolledup[*x];
+                    p.cpu_percentage += proc_info.cpu_percentage;
+                    p.cputime_sec += proc_info.cputime_sec;
+                    p.mem_percentage += proc_info.mem_percentage;
+                    p.mem_size_kib += proc_info.mem_size_kib;
+                    p.gpu_cards.extend(&proc_info.gpu_cards);
+                    p.gpu_percentage += proc_info.cpu_percentage;
+                    p.gpu_mem_percentage += proc_info.gpu_mem_percentage;
+                    p.gpu_mem_size_kib += proc_info.gpu_mem_size_kib;
+                    p.rolledup += 1;
+                } else {
+                    let x = rolledup.len();
+                    index.insert(key, x);
+                    rolledup.push(proc_info.clone());
+                    // We do not increment the clone's `rolledup` counter here because that counter
+                    // counts how many *other* records have been rolled into the canonical one, 0
+                    // means "no interesting information" and need not be printed.
+                }
+            }
         }
-        // "unknown" is not implemented, see https://github.com/NordicHPC/sonar/issues/75
-        let mut gpus_comma_separated: String = proc_info
-            .gpu_cards
-            .iter()
-            .map(|&num| num.to_string())
-            .collect::<Vec<String>>()
-            .join(",");
 
-        if gpus_comma_separated.is_empty() {
-            gpus_comma_separated = "none".to_string();
+        for r in rolledup {
+            print_record(&mut writer, &print_params, &r); 
         }
-
-        writer
-            .write_record([
-                &format!("v={VERSION}"),
-                &format!("time={timestamp}"),
-                &format!("host={hostname}"),
-                &format!("cores={num_cores}"),
-                &format!("user={}", proc_info.user),
-                &format!("job={}", proc_info.job_id),
-                &format!("cmd={}", proc_info.command),
-                &format!("cpu%={}", three_places(proc_info.cpu_percentage)),
-                &format!("cpukib={}", proc_info.mem_size_kib),
-                &format!("gpus={}", gpus_comma_separated),
-                &format!("gpu%={}", three_places(proc_info.gpu_percentage)),
-                &format!("gpumem%={}", three_places(proc_info.gpu_mem_percentage)),
-                &format!("gpukib={}", proc_info.gpu_mem_size_kib),
-                &format!("cputime_sec={}", proc_info.cputime_sec),
-            ])
-            .unwrap();
+    } else {
+        for (_, proc_info) in proc_by_pid {
+            print_record(&mut writer, &print_params, &proc_info);
+        }
     }
 
     writer.flush().unwrap();
+}
+
+struct PrintParameters<'a> {
+    hostname: &'a str,
+    timestamp: &'a str,
+    num_cores: usize,
+    version: &'a str,
+    cpu_cutoff_percent: f64,
+    mem_cutoff_percent: f64,
+}
+
+fn print_record<W: io::Write>(writer: &mut Writer<W>, params: &PrintParameters, proc_info: &ProcInfo) {
+    if (proc_info.cpu_percentage < params.cpu_cutoff_percent) &&
+        (proc_info.mem_percentage < params.mem_cutoff_percent) {
+        return;
+    }
+
+    // "unknown" is not implemented, see https://github.com/NordicHPC/sonar/issues/75
+    let mut gpus_comma_separated: String = proc_info
+        .gpu_cards
+        .iter()
+        .map(|&num| num.to_string())
+        .collect::<Vec<String>>()
+        .join(",");
+
+    if gpus_comma_separated.is_empty() {
+        gpus_comma_separated = "none".to_string();
+    }
+
+    writer
+        .write_record([
+            &format!("v={}", params.version),
+            &format!("time={}", params.timestamp),
+            &format!("host={}", params.hostname),
+            &format!("cores={}", params.num_cores),
+            &format!("user={}", proc_info.user),
+            &format!("job={}", proc_info.job_id),
+            &format!("cmd={}", proc_info.command),
+            &format!("cpu%={}", three_places(proc_info.cpu_percentage)),
+            &format!("cpukib={}", proc_info.mem_size_kib),
+            &format!("gpus={}", gpus_comma_separated),
+            &format!("gpu%={}", three_places(proc_info.gpu_percentage)),
+            &format!("gpumem%={}", three_places(proc_info.gpu_mem_percentage)),
+            &format!("gpukib={}", proc_info.gpu_mem_size_kib),
+            &format!("cputime_sec={}", proc_info.cputime_sec),
+            &format!("rolledup={}", proc_info.rolledup),
+        ])
+        .unwrap();
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,6 @@
+#![allow(unused_imports)]
+#![allow(unused_macros)]
+
 use chrono::prelude::Local;
 
 // Populate a HashSet.


### PR DESCRIPTION
As discussed on #78, the use of user name and command name to distinguish process records and the attempted merging of process records that have the same user name and command name are vestiges of an older design.  This patch removes all of that and does the following:

- the pid is the unique key for a record internally
- information from multiple sources for the same pid are merged into the unique record for the pid
- the record is tagged with its job id but the job id is not a distinguishing characteristic of anything, internally
- as a result, there may be multiple records for the same job in the output, but this was always the case; now it is documented
- the intermediate "rolling up" of ps and gpu records with the same user, pid, and command is not necessary and has been removed
- it is documented that job id 0 in the output is special

So far as I can see, this does not materially change the volume of output data, which is determined mostly by filtering anyway.  I've kept the existing filtering here but moved it down to the output phase, so there may be very slight changes in the output produced, but this is not expected to be material, see #73 for longer discussion.