### PR TITLE
more robust date query; closes #103

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,7 @@ set -euf -o pipefail
 
 sonar_directory=/cluster/shared/sonar/data
 
-year=$(date +'%Y')
-month=$(date +'%m')
-day=$(date +'%d')
+read -r year month day <<< $(date +"%Y %m %d")
 
 output_directory=${sonar_directory}/${year}/${month}/${day}
 


### PR DESCRIPTION
One `date` invocation instead of three.