### PR TITLE
Make timeout 5s, and share it.  Fix #92.

### DIFF
--- a/src/amd.rs
+++ b/src/amd.rs
@@ -16,6 +16,7 @@
 use crate::command::{self, CmdError};
 use crate::nvidia;
 use crate::ps::UserTable;
+use crate::TIMEOUT_SECONDS;
 
 use std::cmp::Ordering;
 
@@ -138,8 +139,6 @@ PID 28154 is using 1 DRM device(s):
         proc! { Some(1), 28156, "bob", 1001, 63.0, 5.0 },
     ]));
 }
-
-const TIMEOUT_SECONDS: u64 = 2; // For `rocm-smi`
 
 const AMD_CONCISE_COMMAND: &str = "rocm-smi";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ mod ps;
 mod slurm;
 mod util;
 
+const TIMEOUT_SECONDS: u64 = 5; // For subprocesses
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -9,6 +9,7 @@
 use crate::command::{self, CmdError};
 use crate::util;
 use crate::ps::UserTable;
+use crate::TIMEOUT_SECONDS;
 
 #[cfg(test)]
 use crate::util::map;
@@ -48,8 +49,6 @@ pub fn get_nvidia_information(
         Err(e) => Err(format!("{:?}", e)),
     }
 }
-
-const TIMEOUT_SECONDS: u64 = 2; // For `nvidia-smi`
 
 // For prototyping purposes (and maybe it's good enough for production?), parse the output of
 // `nvidia-smi pmon`.  This output has a couple of problems:

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,7 @@
 /// Collect CPU process information without GPU information, by running `ps`.
 
 use crate::command::{self, CmdError};
+use crate::TIMEOUT_SECONDS;
 use crate::util;
 
 #[derive(PartialEq)]
@@ -26,8 +27,6 @@ pub fn get_process_information() -> Result<Vec<Process>, CmdError> {
         Err(e) => Err(e),
     }
 }
-
-const TIMEOUT_SECONDS: u64 = 2; // for `ps`
 
 // `--cumulative` and `bsdtime` are to make sure that the cpu time accounted to exited child
 // processes (the cutime and cstime fields of /proc/pid/status) is used and printed.  Note


### PR DESCRIPTION
This seems to take care of the timeout problems I was seeing on our busiest systems.