### PR TITLE
Fix #107: Always print at least one record

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ fn main() {
         } => {
             let opts = ps::PsOptions {
                 rollup: *rollup,
+                always_print_something: true,
                 min_cpu_percent: *min_cpu_percent,
                 min_mem_percent: *min_mem_percent,
                 min_cpu_time: *min_cpu_time,


### PR DESCRIPTION
Draft, pending resolution to the discussion in #107, but ready to go if this is how we decide to do it.

This prints a synthetic heartbeat record from `sonar ps` if nothing else has been printed, and does not need a command line switch to do so - it always does it.  Easy to add a switch if we need it.