### PR TITLE
For #152 - remove wait-timeout dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,6 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "subprocess",
- "wait-timeout",
 ]
 
 [[package]]
@@ -498,15 +497,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 subprocess = "0.2"
-wait-timeout = "0.2"
 chrono = "0.4"
 hostname = "0.3"
 num_cpus = "1.16"


### PR DESCRIPTION
The wait-timeout library is no longer used by sonar, it's a dead dependency in Cargo.toml.