### PR TITLE
For #152 - Remove env_logger and log dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,29 +180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e7cf40684ae96ade6232ed84582f40ce0a66efcd43a5117aef610534f8e0b8"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,12 +195,6 @@ dependencies = [
  "match_cfg",
  "winapi",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -340,35 +302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,10 +364,8 @@ dependencies = [
  "chrono",
  "clap",
  "csv",
- "env_logger",
  "hostname",
  "libc",
- "log",
  "page_size",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ chrono = "0.4"
 hostname = "0.3"
 clap = { version = "4.5", features = ["derive"] }
 csv = "1.3"
-log = "0.4"
-env_logger = "0.11"
 page_size = "0.6"
 libc = "0.2"
 signal-hook = "0.3"

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,13 @@
+// A trivial logging package, that can be replaced by something more interesting if necessary.
+
+pub fn init() {
+    // Currently nothing
+}
+
+pub fn info(s: &str) {
+    eprintln!("Info: {s}");
+}
+
+pub fn error(s: &str) {
+    eprintln!("Error: {s}");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-extern crate env_logger;
-
 use clap::{Parser, Subcommand};
 
 mod amd;
@@ -7,6 +5,7 @@ mod batchless;
 mod command;
 mod gpu;
 mod jobs;
+mod log;
 mod nvidia;
 mod procfs;
 mod procfsapi;
@@ -81,7 +80,7 @@ fn main() {
     // improperly reflects the true order in which they were obtained.  See #100.
     let timestamp = util::time_iso8601();
 
-    env_logger::init();
+    log::init();
 
     let cli = Cli::parse();
 

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
-extern crate log;
-
 use crate::amd;
 use crate::jobs;
+use crate::log;
 use crate::nvidia;
 use crate::procfs;
 use crate::procfsapi;
@@ -258,10 +257,10 @@ pub fn create_snapshot(jobs: &mut dyn jobs::JobManager, opts: &PsOptions, timest
         }
 
         if skip {
-            log::info!("Lockfile present, exiting");
+            log::info("Lockfile present, exiting");
         }
         if failed {
-            log::error!("Unable to properly manage or delete lockfile");
+            log::error("Unable to properly manage or delete lockfile");
         }
     } else {
         do_create_snapshot(jobs, opts, timestamp, &interrupted);
@@ -289,7 +288,7 @@ fn do_create_snapshot(
     let memtotal_kib = match procfs::get_memtotal_kib(&fs) {
         Ok(n) => n,
         Err(e) => {
-            log::error!("Could not get installed memory: {}", e);
+            log::error(&format!("Could not get installed memory: {e}"));
             return;
         }
     };
@@ -297,8 +296,7 @@ fn do_create_snapshot(
     let procinfo_output = match procfs::get_process_information(&fs, memtotal_kib) {
         Ok(result) => result,
         Err(msg) => {
-            eprintln!("procfs failed: {msg}");
-            log::error!("procfs failed: {msg}");
+            log::error(&format!("procfs failed: {msg}"));
             return;
         }
     };
@@ -348,7 +346,7 @@ fn do_create_snapshot(
             gpu_status = GpuStatus::UnknownFailure;
             // This is a soft failure, surfaced through dashboards; we do not want mail about it
             // under normal circumstances.
-            //log::error!("GPU (Nvidia) process listing failed: {:?}", e);
+            //log::error(&format!("GPU (Nvidia) process listing failed: {:?}", e));
         }
         Ok(ref nvidia_output) => {
             for proc in nvidia_output {
@@ -383,7 +381,7 @@ fn do_create_snapshot(
             gpu_status = GpuStatus::UnknownFailure;
             // This is a soft failure, surfaced through dashboards; we do not want mail about it
             // under normal circumstances.
-            //log::error!("GPU (AMD) process listing failed: {:?}", e);
+            //log::error(&format!("GPU (AMD) process listing failed: {:?}", e));
         }
         Ok(ref amd_output) => {
             for proc in amd_output {

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -1,7 +1,6 @@
-extern crate log;
-
 use crate::amd;
 use crate::gpu;
+use crate::log;
 use crate::nvidia;
 use crate::procfs;
 use crate::procfsapi;
@@ -15,7 +14,7 @@ pub fn show_system(timestamp: &str) {
     match do_show_system(&fs, timestamp) {
         Ok(_) => {}
         Err(e) => {
-            log::error!("sysinfo failed: {e}");
+            log::error(&format!("sysinfo failed: {e}"));
         }
     }
 }


### PR DESCRIPTION
Still thinking about this, but currently sonar is not using any of the functionality of env_logger or log: it just writes the error message on stderr.  And the conclusion in #52 was that this is Just Fine.  Ergo the logging functions, which are ergonomically right, need only be thin wrappers around eprintln.

This gets rid of lots of dependencies since env_logger pulls in regexp and its dependencies, among other things.  Binary size drops by 50%.