### PR TITLE
For #152 - Remove hostname dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,17 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,12 +272,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "memchr"
@@ -432,7 +415,6 @@ dependencies = [
  "clap",
  "csv",
  "env_logger",
- "hostname",
  "libc",
  "log",
  "page_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 subprocess = "0.2"
 chrono = "0.4"
-hostname = "0.3"
 clap = { version = "4.5", features = ["derive"] }
 csv = "1.3"
 log = "0.4"

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -1,0 +1,69 @@
+// Origin of this code: https://github.com/svartalf/hostname.
+
+/*
+
+MIT License
+
+Copyright (c) 2016 fengcen
+Copyright (c) 2019 svartalf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+ */
+
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use std::io;
+use libc;
+
+pub fn get() -> io::Result<OsString> {
+    // According to the POSIX specification,
+    // host names are limited to `HOST_NAME_MAX` bytes
+    //
+    // https://pubs.opengroup.org/onlinepubs/9699919799/functions/gethostname.html
+    let size =
+        unsafe { libc::sysconf(libc::_SC_HOST_NAME_MAX) as libc::size_t };
+
+    // Stack buffer OK: HOST_NAME_MAX is typically very small (64 on Linux).
+    let mut buffer = vec![0u8; size];
+
+    let result = unsafe {
+        libc::gethostname(buffer.as_mut_ptr() as *mut libc::c_char, size)
+    };
+
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(wrap_buffer(buffer))
+}
+
+fn wrap_buffer(mut bytes: Vec<u8>) -> OsString {
+    // Returned name might be truncated if it does not fit
+    // and `buffer` will not contain the trailing \0 in that case.
+    // Manually capping the buffer length here.
+    let end = bytes
+        .iter()
+        .position(|&byte| byte == 0x00)
+        .unwrap_or_else(|| bytes.len());
+    bytes.resize(end, 0x00);
+
+    OsString::from_vec(bytes)
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod amd;
 mod batchless;
 mod command;
 mod gpu;
+mod hostname;
 mod jobs;
 mod nvidia;
 mod procfs;

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -4,6 +4,7 @@
 extern crate log;
 
 use crate::amd;
+use crate::hostname;
 use crate::jobs;
 use crate::nvidia;
 use crate::procfs;

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -2,6 +2,7 @@ extern crate log;
 
 use crate::amd;
 use crate::gpu;
+use crate::hostname;
 use crate::nvidia;
 use crate::procfs;
 use crate::procfsapi;


### PR DESCRIPTION
Not the biggest thing, but the code is simple, MIT-licensed, and depends only on libc, so let's just incorporate the one function we need.  In this respect it is like the `users` library we also incorporated previously.
