### PR TITLE
For #152 - Remove chrono dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,21 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,47 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bumpalo"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-targets",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,12 +104,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "csv"
@@ -235,42 +173,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "js-sys"
-version = "0.3.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "libc"
@@ -295,21 +201,6 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "num-traits"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "page_size"
@@ -428,7 +319,6 @@ dependencies = [
 name = "sonar"
 version = "0.10.0"
 dependencies = [
- "chrono",
  "clap",
  "csv",
  "env_logger",
@@ -482,60 +372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,15 +392,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 subprocess = "0.2"
-chrono = "0.4"
 hostname = "0.3"
 clap = { version = "4.5", features = ["derive"] }
 csv = "1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod procfsapi;
 mod ps;
 mod slurm;
 mod sysinfo;
+mod time;
 mod users;
 mod util;
 
@@ -79,7 +80,7 @@ fn main() {
     // obtained, not the time when reporting was allowed to run.  The latter is subject to greater
     // system effects, and using that timestamp increases the risk that the samples' timestamp order
     // improperly reflects the true order in which they were obtained.  See #100.
-    let timestamp = util::time_iso8601();
+    let timestamp = time::now_iso8601();
 
     env_logger::init();
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,70 @@
+use libc;
+use std::ffi::CStr;
+
+// Get current time as an ISO time stamp: yyyy-mm-ddThh:mm:ss+hhmm
+//
+// Use libc to avoid pulling in all of Chrono for this:
+//   t = time()
+//   localtime_r(&t, timebuf)
+//   strftime(strbuf, strbufsize, "%FT%T%z", timebuf)
+//
+// Panic on errors, there should never be any.
+
+pub fn now_iso8601() -> String {
+    let mut timebuf = libc::tm {
+        tm_sec: 0,
+        tm_min: 0,
+        tm_hour: 0,
+        tm_mday: 0,
+        tm_mon: 0,
+        tm_year: 0,
+        tm_wday: 0,
+        tm_yday: 0,
+        tm_isdst: 0,
+        tm_gmtoff: 0,
+        tm_zone: std::ptr::null(),
+    };
+    const SIZE: usize = 32;     // We need 25 unless something is greatly off
+    let mut buffer = vec![0i8; SIZE];
+    unsafe {
+        let t = libc::time(std::ptr::null_mut());
+
+        if libc::localtime_r(&t, &mut timebuf) == std::ptr::null_mut() {
+            panic!("localtime_r");
+        }
+
+        // strftime returns 0 if the buffer is too small for the result + NUL.
+        if libc::strftime(
+            buffer.as_mut_ptr(),
+            SIZE,
+            CStr::from_bytes_with_nul_unchecked(b"%FT%T%z\0").as_ptr(),
+            &timebuf) == 0 {
+            panic!("strftime");
+        }
+
+        return CStr::from_ptr(buffer.as_ptr()).to_str().unwrap().to_string();
+    }
+}
+
+#[test]
+pub fn test_isotime() {
+    let t = now_iso8601();
+    let ts = t.as_str().chars().collect::<Vec<char>>();
+    let expect = "dddd-dd-ddTdd:dd:dd+dddd";
+    let mut i = 0;
+    for c in expect.chars() {
+        match c {
+            'd' => {
+                assert!(ts[i] >= '0' && ts[i] <= '9');
+            }
+            '+' => {
+                assert!(ts[i] == '+' || ts[i] == '-');
+            }
+            _ => {
+                assert!(ts[i] == c);
+            }
+        }
+        i += 1;
+    }
+    assert!(i == ts.len());
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,6 @@
 #![allow(unused_imports)]
 #![allow(unused_macros)]
 
-use chrono::prelude::Local;
-
 // Populate a HashSet.
 #[cfg(test)]
 macro_rules! set(
@@ -36,12 +34,6 @@ pub(crate) use map;
 
 #[cfg(test)]
 pub(crate) use set;
-
-// Get current time as an ISO time stamp.
-pub fn time_iso8601() -> String {
-    let local_time = Local::now();
-    format!("{}", local_time.format("%Y-%m-%dT%H:%M:%S%Z"))
-}
 
 // Carve up a line of text into space-separated chunks + the start indices of the chunks.
 pub fn chunks(input: &str) -> (Vec<usize>, Vec<&str>) {


### PR DESCRIPTION
Libc has everything we need, so just get rid of chrono altogether.  With all the patches applied we are now down to four explicit dependencies and 9 in total (and code size is reduced by approximately 75%).
