### PR TITLE
For #152 - Limit signal-hook features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ log = "0.4"
 env_logger = "0.11"
 page_size = "0.6"
 libc = "0.2"
-signal-hook = "0.3"
+signal-hook = { version = "0.3", default-features = false, features = [] }
 serde_json = "1.0.114"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
Disable features we don't need (we only need the "set a flag atomically" feature), until we can figure out if it's possible to get rid of this dependency.