### PR TITLE
Fix #178 - extract numa info

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -9,6 +9,7 @@
       "name": "Bockwoldt, Mathias"
     },
     {
+      "affiliation": "University of Oslo",
       "name": "Hansen, Lars T."
     },
     {
@@ -25,5 +26,5 @@
     "id": "GPL-3.0"
   },
   "title": "sonar: Tool to profile usage of HPC resources by regularly probing processes using ps.",
-  "version": "0.11.0"
+  "version": "0.12.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "sonar"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "libc",
  "subprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonar"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Usage: sonar <COMMAND>
 Commands:
   ps       Take a snapshot of the currently running processes
   sysinfo  Extract system information
-  analyze  Not yet implemented
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -49,6 +48,11 @@ The bugfix version is updated for changes that do not alter the output format pe
 affect the output nevertheless, ie, most changes not covered by changes to the minor version number.
 
 These rules are new with v0.8.0.
+
+### Changes in v0.12.x
+
+**System load data introduced**.  Added the `load` field which is printed with one of the records
+per sonar invocation. (v0.12.0)
 
 ### Changes in v0.11.x
 
@@ -178,6 +182,27 @@ v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,
 v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=pulseaudio,cpu%=0.7,cpukib=90640,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=399
 v=0.7.0,time=2023-08-10T11:09:41+02:00,host=somehost,cores=8,user=someone,job=0,cmd=slack,cpu%=3.9,cpukib=716924,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=266
 ```
+
+### Version 0.12.0 `ps` output format
+
+Version 0.12.0 adds one field:
+
+`load` (optional, default blank): This is an encoding of the per-cpu time usage in seconds on the
+node since boot.  It is the same for all records and is therefore printed only with one of them per
+sonar invocation.  The encoding is an array of N+1 u64 values for an N-cpu node.  The first value is
+the "base" value, it is to be added to all the subsequent values.  The remaining are per-cpu values
+in order from cpu0 through cpuN-1.  Each value is encoded little-endian base-45, with the initial
+character of each value chosen from a different set than the subsequent characters.  The character
+sets are:
+
+```
+INITIAL = "(){}[]<>+-abcdefghijklmnopqrstuvwxyz!@#$%^&*_"
+SUBSEQUENT = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ~|';:.?/`"
+```
+
+The base-45 digits of the value `897` are (in little-endian order) 42 and 19, and the encoding of
+this value is thus `&J`.  As the initial character is from a different character set, no explicit
+separator is needed in the array - the initial digit acts as a separator.
 
 ### Version 0.11.0 `ps` output format
 
@@ -366,9 +391,9 @@ Numeric fields that are zero may or may not be omitted by the producer.
 
 Note the v0.9.0 `sysinfo` output does not carry a version number.
 
-## Collect results with `sonar analyze` :construction:
+## Collect and analyze results
 
-The `analyze` command is work in progress.  Sonar data are used by two other tools:
+Sonar data are used by two other tools:
 
 * [JobGraph](https://github.com/NordicHPC/jobgraph) provides high-level plots of system activity. Mapping
   files for JobGraph can be found in the [data](data) folder.

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,10 @@ enum Commands {
 
         /// Create a per-host lockfile in this directory and exit early if the file exists on startup [default: none]
         lockdir: Option<String>,
+
+        /// One output record per Sonar invocation will contain a load= field with an encoding of
+        /// the per-cpu usage since boot.
+        load: bool,
     },
     /// Extract system information
     Sysinfo {},
@@ -76,6 +80,7 @@ fn main() {
             exclude_users,
             exclude_commands,
             lockdir,
+            load,
         } => {
             let opts = ps::PsOptions {
                 rollup: *rollup,
@@ -84,6 +89,7 @@ fn main() {
                 min_mem_percent: *min_mem_percent,
                 min_cpu_time: *min_cpu_time,
                 exclude_system_jobs: *exclude_system_jobs,
+                load: *load,
                 exclude_users: if let Some(s) = exclude_users {
                     s.split(',').collect::<Vec<&str>>()
                 } else {
@@ -131,6 +137,7 @@ fn command_line() -> Commands {
                 let mut exclude_users = None;
                 let mut exclude_commands = None;
                 let mut lockdir = None;
+                let mut load = false;
                 while next < args.len() {
                     let arg = args[next].as_ref();
                     next += 1;
@@ -138,6 +145,8 @@ fn command_line() -> Commands {
                         (next, batchless) = (new_next, true);
                     } else if let Some(new_next) = bool_arg(arg, &args, next, "--rollup") {
                         (next, rollup) = (new_next, true);
+                    } else if let Some(new_next) = bool_arg(arg, &args, next, "--load") {
+                        (next, load) = (new_next, true);
                     } else if let Some(new_next) =
                         bool_arg(arg, &args, next, "--exclude-system-jobs")
                     {
@@ -192,6 +201,7 @@ fn command_line() -> Commands {
                     exclude_users,
                     exclude_commands,
                     lockdir,
+                    load,
                 }
             }
             "sysinfo" => Commands::Sysinfo {},

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -744,16 +744,19 @@ fn print_record(
 
 // Encode a nonempty u64 array compactly.
 //
-// The values to be represented are always cpu seconds of active time since boot, one item per cpu.
 // The output must be ASCII text (32 <= c < 128), ideally without ',' or '"' or '\' or ' ' to not
-// make it difficult for the various output formats we use.
+// make it difficult for the various output formats we use.  Also avoid DEL, because it is a weird
+// control character.
 //
 // We have many encodings to choose from, see https://github.com/NordicHPC/sonar/issues/178.
 //
-// The encoding here first finds the minimum input value and subtracts that from all entries.  The
+// The values to be represented are always cpu seconds of active time since boot, one item per cpu,
+// and it is assumed that they are roughly in the vicinity of each other (the largest is rarely more
+// than 4x the smallest, say).  The assumption does not affect correctness, only compactness.
+//
+// The encoding first finds the minimum input value and subtracts that from all entries.  The
 // minimum value, and all the entries, are then emitted as unsigned little-endian base-45 with the
-// initial digit chosen from a different character set to indicate that it is initial.  The
-// algorithm is simple and reasonably fast for our data volumes.
+// initial digit chosen from a different character set to indicate that it is initial.
 
 fn encode_cpu_secs_base45el(cpu_secs: &[u64]) -> String {
     let base = *cpu_secs

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -173,6 +173,7 @@ pub struct PsOptions<'a> {
     pub exclude_users: Vec<&'a str>,
     pub exclude_commands: Vec<&'a str>,
     pub lockdir: Option<String>,
+    pub load: bool,
 }
 
 pub fn create_snapshot(jobs: &mut dyn jobs::JobManager, opts: &PsOptions, timestamp: &str) {
@@ -719,9 +720,11 @@ fn print_record(
     if proc_info.rolledup > 0 {
         fields.push(format!("rolledup={}", proc_info.rolledup));
     }
-    if let Some(cpu_secs) = per_cpu_secs {
-        if cpu_secs.len() > 0 {
-            fields.push(format!("load={}", encode_cpu_secs_base45el(cpu_secs)))
+    if params.opts.load {
+        if let Some(cpu_secs) = per_cpu_secs {
+            if cpu_secs.len() > 0 {
+                fields.push(format!("load={}", encode_cpu_secs_base45el(cpu_secs)))
+            }
         }
     }
 

--- a/tests/load.sh
+++ b/tests/load.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Test that we can emit per-cpu load data properly.
+
+set -e
+
+( cd .. ; cargo build )
+loadlines=$(../target/debug/sonar ps --load | grep ',load=' | wc -l)
+if [[ $loadlines -ne 1 ]]; then
+    echo "Did not emit load data properly - not exactly 1"
+    exit 1
+fi
+
+loadlines=$(../target/debug/sonar ps | grep ',load=' | wc -l)
+if [[ $loadlines -ne 0 ]]; then
+    echo "Did not emit load data properly - not exactly 0"
+    exit 1
+fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,6 +20,7 @@ for test in command-line \
                 exclude-users \
                 hostname \
                 interrupt \
+                load \
                 lockfile \
                 min-cpu-time \
                 ps-syntax \


### PR DESCRIPTION
Currently a WIP, decoding /proc/stat and outlining various representation strategies for the data to make them compact.  There are endless possibilities, but a base-45 variable-length delta-from-minimum encoding with separators represented as distinguished leading digits is probably about as compact as more standard encodings (eg uleb64+base64), and simpler than the latter.