### PR TITLE
Fix #168 - get rid of all cases of unwrap()

### DIFF
--- a/src/amd.rs
+++ b/src/amd.rs
@@ -175,7 +175,7 @@ PID 28154 is using 1 DRM device(s):
     let users = map! {
     28156 => ("bob", 1001usize)
     };
-    let zs = extract_amd_information(concise, pidgpu, &users).unwrap();
+    let zs = extract_amd_information(concise, pidgpu, &users).expect("Test: AMD information");
     assert!(zs.eq(&vec![
         proc! { Some(0), 28154, "_zombie_28154", gpu::ZOMBIE_UID, 99.0/2.0, 57.0/2.0 },
         proc! { Some(0), 28156, "bob", 1001, 99.0/2.0, 57.0/2.0 },
@@ -203,14 +203,16 @@ fn parse_concise_command(raw_text: &str) -> Result<Vec<(f64, f64)>, String> {
             while i < block.len() {
                 let fields = block[i].split_whitespace().collect::<Vec<&str>>();
                 let dev = fields[0].parse::<usize>().unwrap_or_default();
+                // The fields should have the format N% and if they don't we always
+                // default to 0.
                 let mem = fields[fields.len() - 2]
                     .strip_suffix('%')
-                    .unwrap()
+                    .unwrap_or("0")
                     .parse::<f64>()
                     .unwrap_or_default();
                 let gpu = fields[fields.len() - 1]
                     .strip_suffix('%')
-                    .unwrap()
+                    .unwrap_or("0")
                     .parse::<f64>()
                     .unwrap_or_default();
                 if mappings.len() < dev + 1 {
@@ -239,7 +241,7 @@ GPU  Temp (DieEdge)  AvgPwr  SCLK     MCLK    Fan     Perf  PwrCap  VRAM%  GPU%
 ================================================================================
 ",
     )
-    .unwrap();
+    .expect("Test: Must have data");
     assert!(xs.eq(&vec![(99.0, 57.0), (63.0, 5.0)]));
 }
 
@@ -295,7 +297,7 @@ PID 25774 is using 1 DRM device(s):
 ================================================================================
 ",
     )
-    .unwrap();
+    .expect("Test: Must have data");
     assert!(xs.eq(&vec![(25774, vec![0])]));
     let xs = parse_showpidgpus_command(
         "
@@ -304,7 +306,7 @@ No KFD PIDs currently running
 ================================================================================
 ",
     )
-    .unwrap();
+    .expect("Test: Must have data");
     assert!(xs.eq(&vec![]));
 
     let xs = parse_showpidgpus_command(
@@ -317,7 +319,7 @@ PID 28154 is using 1 DRM device(s):
 ================================================================================
 ",
     )
-    .unwrap();
+    .expect("Test: Must have data");
     assert!(xs.eq(&vec![(28156, vec![1]), (28154, vec![0])]));
     let xs = parse_showpidgpus_command(
         "
@@ -327,7 +329,7 @@ PID 29212 is using 2 DRM device(s):
 ================================================================================
 ",
     )
-    .unwrap();
+    .expect("Test: Must have data");
     assert!(xs.eq(&vec![(29212, vec![0, 1])]));
 }
 

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -31,7 +31,19 @@ use std::ffi::OsString;
 use std::io;
 use std::os::unix::ffi::OsStringExt;
 
-pub fn get() -> io::Result<OsString> {
+pub fn get() -> String {
+    match primitive_get() {
+        Ok(hn) => {
+            match hn.into_string() {
+                Ok(s) => s,
+                Err(_) => "unknown-host".to_string()
+            }
+        }
+        Err(_) => "unknown-host".to_string()
+    }
+}
+
+pub fn primitive_get() -> io::Result<OsString> {
     // According to the POSIX specification,
     // host names are limited to `HOST_NAME_MAX` bytes
     //

--- a/src/procfsapi.rs
+++ b/src/procfsapi.rs
@@ -92,7 +92,7 @@ impl ProcfsAPI for RealFS {
 pub fn unix_now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
+        .expect("System time precedes epoch")
         .as_secs()
 }
 

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -48,7 +48,9 @@ fn union_gpuset(lhs: &mut GpuSet, rhs: &GpuSet) {
     } else if rhs.is_none() {
         *lhs = None;
     } else {
-        lhs.as_mut().unwrap().extend(rhs.as_ref().unwrap());
+        lhs.as_mut()
+            .expect("LHS is nonempty")
+            .extend(rhs.as_ref().expect("RHS is nonempty"));
     }
 }
 
@@ -198,7 +200,7 @@ pub fn create_snapshot(jobs: &mut dyn jobs::JobManager, opts: &PsOptions, timest
         let mut created = false;
         let mut failed = false;
         let mut skip = false;
-        let hostname = hostname::get().unwrap().into_string().unwrap();
+        let hostname = hostname::get();
 
         let mut p = PathBuf::new();
         p.push(dirname);
@@ -434,7 +436,7 @@ fn do_create_snapshot(jobs: &mut dyn jobs::JobManager, opts: &PsOptions, timesta
 
     let mut writer = io::stdout();
 
-    let hostname = hostname::get().unwrap().into_string().unwrap();
+    let hostname = hostname::get();
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     let print_params = PrintParameters {
         hostname: &hostname,
@@ -762,7 +764,7 @@ fn encode_cpu_secs_base45el(cpu_secs: &[u64]) -> String {
     let base = *cpu_secs
         .iter()
         .reduce(std::cmp::min)
-        .expect("Non-empty");
+        .expect("Must have a non-empty array");
     let mut s = encode_u64_base45el(base);
     for x in cpu_secs {
         s += encode_u64_base45el(*x - base).as_str();

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -37,7 +37,7 @@ fn do_show_system(
     } else {
         vec![]
     };
-    let hostname = hostname::get().unwrap().into_string().unwrap();
+    let hostname = hostname::get();
     let ht = if threads_per_core > 1 {
         " (hyperthreaded)"
     } else {


### PR DESCRIPTION
In test cases, use `expect` instead of `unwrap`, with a string that clearly marks it as a test case.

In most other cases, use `expect` if there was an existing check on the path (typically `is_some`) and otherwise rewrite the code using `match`.

In a couple of cases, the `expect` checks a complex precondition and now properly documents that.

There are two cases of `panic` that have been commented but left alone.