### PR TITLE
Fix #229 - gpu probe regression

### DIFF
--- a/src/ps.rs
+++ b/src/ps.rs
@@ -342,12 +342,12 @@ fn do_create_snapshot(jobs: &mut dyn jobs::JobManager, opts: &PsOptions, timesta
     let gpu_utilization: Vec<gpu::Process>;
     let mut gpu_info: String = "".to_string();
     match gpu::probe() {
-        None => {
-            gpu_status = GpuStatus::UnknownFailure;
-        }
+        None => {}
         Some(mut gpu) => {
             match gpu.get_card_utilization() {
-                Err(_) => {}
+                Err(_) => {
+                    gpu_status = GpuStatus::UnknownFailure;
+                }
                 Ok(ref cards) => {
                     let mut s = "".to_string();
                     s = add_key(s, "fan%", cards, |c: &gpu::CardState| {

--- a/tests/no-gpu.sh
+++ b/tests/no-gpu.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# First check that `sonar sysinfo` will detect no GPUs if there are no GPUs.
+#
+# Next check and that there are no GPU fields in the output from `sonar ps`.
+
+# Requirement: the `jq` utility.
+
+# Add other GPU types here when we add support for them, the tests below should start failing when
+# that happens.
+set -e
+if [[ -e /sys/module/amdgpu || -e /sys/module/nvidia ]]; then
+    echo "GPUs detected"
+    exit 0
+fi
+
+( cd .. ; cargo build )
+
+output=$(../target/debug/sonar sysinfo)
+numcards=$(jq .gpu_cards <<< $output)
+if (( $numcards != 0 )); then
+    echo "Bad output from jq: <$numcards> should be zero"
+    exit 1
+fi
+
+# TODO: Once we have JSON output, use that here!  The CSV matching is very crude and there's a small
+# chance that it will have a false positive on sufficiently perverse command names.
+
+output=$(../target/debug/sonar ps --load)
+if [[ $output =~ ,gpu[%a-z_-]+= ]]; then
+    echo "Bad output: unexpected GPU fields in output on non-gpu system"
+    exit 1
+fi
+
+echo "OK"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Primitive test runner.
+# Primitive test runner, to run locally and on CI.
 
 set -e
 
@@ -25,6 +25,7 @@ for test in amd-gpu \
                 load \
                 lockfile \
                 min-cpu-time \
+                no-gpu \
                 nvidia-gpu \
                 ps-syntax \
                 rollup \


### PR DESCRIPTION
Move the setting of the error flag into an error case, add a test case.