### PR TITLE
For #147 - Daemon with stdio exfiltration/control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target/
 *~
 *.rej
 *.orig
-util/ingest-files/ingest-files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/NordicHPC/sonar"
 nvidia = []
 amd = []
 xpu = []
-default = [ "nvidia", "amd" ]
+daemon = []
+default = [ "nvidia", "amd", "daemon" ]
 
 [dependencies]
 cty = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -53,31 +53,37 @@ It's sensible to run `sonar ps` every 5 minutes on every compute node.
 
 ```console
 $ sonar ps --help
-Take a snapshot of the currently running processes
 
-Usage: sonar ps [OPTIONS]
+...
 
-Options:
-      --batchless
-          Synthesize a job ID from the process tree in which a process finds itself
-      --rollup
-          Merge process records that have the same job ID and command name
-      --min-cpu-percent <MIN_CPU_PERCENT>
-          Include records for jobs that have on average used at least this percentage of CPU, note this is nonmonotonic [default: none]
-      --min-mem-percent <MIN_MEM_PERCENT>
-          Include records for jobs that presently use at least this percentage of real memory, note this is nonmonotonic [default: none]
-      --min-cpu-time <MIN_CPU_TIME>
-          Include records for jobs that have used at least this much CPU time (in seconds) [default: none]
-      --exclude-system-jobs
-          Exclude records for system jobs (uid < 1000)
-      --exclude-users <EXCLUDE_USERS>
-          Exclude records for these comma-separated user names [default: none]
-      --exclude-commands <EXCLUDE_COMMANDS>
-          Exclude records whose commands start with these comma-separated names [default: none]
-      --lockdir <LOCKDIR>
-          Create a per-host lockfile in this directory and exit early if the file exists on startup [default: none]
-  -h, --help
-          Print help
+Options for `ps`:
+  --rollup
+      Merge process records that have the same job ID and command name (on systems
+      with stable job IDs only)
+  --min-cpu-time seconds
+      Include records for jobs that have used at least this much CPU time
+      [default: none]
+  --exclude-system-jobs
+      Exclude records for system jobs (uid < 1000)
+  --exclude-users user,user,...
+      Exclude records whose users match these names [default: none]
+  --exclude-commands command,command,...
+      Exclude records whose commands start with these names [default: none]
+  --min-cpu-percent percentage
+      Include records for jobs that have on average used at least this
+      percentage of CPU, NOTE THIS IS NONMONOTONIC [default: none]
+  --min-mem-percent percentage
+      Include records for jobs that presently use at least this percentage of
+      real memory, NOTE THIS IS NONMONOTONIC [default: none]
+  --lockdir directory
+      Create a per-host lockfile in this directory and exit early if the file
+      exists on startup [default: none]
+  --load
+      Print per-cpu and per-gpu load data
+  --json
+      Format output as new JSON, not CSV
+  --cluster name
+      Optional cluster name (required for --json) with which to tag output
 ```
 
 **NOTE** that if you use `--lockdir`, it should name a directory that is cleaned on reboot, such as

--- a/doc/HOWTO-DAEMON.md
+++ b/doc/HOWTO-DAEMON.md
@@ -1,0 +1,135 @@
+# Daemon mode
+
+In the "daemon mode", Sonar stays memory-resident and pushes data to a sink.  In this mode, the only
+command line parameter is the name of a config file.
+
+The daemon is a multi-threaded system that performs system sampling, communicates with the sink, and
+handles signals and lock files.
+
+## CONFIG FILE
+
+The config file is an ini-type file.  Blank lines and lines starting with '#' are ignored.  Each
+section has a `[section-name]` header on a line by itself.  Within the sections, there are
+`name=value` pairs where names are simple identifiers matching `/[a-zA-Z_][-a-zA-Z_0-9]*/` and values
+may be quoted with `'`, `"`, or "`"; these quotes are stripped.  Blanks before and after names and
+values are stripped.
+
+Boolean values are `true` or `false`.  Duration values express a time value using the syntax `__h`,
+`__m`, or `__s`, denoting hour, minute, or second values (uppercase HMS also allowed); values must
+be nonzero. For cadences, second values must divide a minute evently and be < 60, minute values must
+divide an hour evenly and < 60, and hour values must divide a day evenly or be a positive multiple
+of 24.  (Some sensible cadences such as 90m aka 1h30m are not currently expressible.)
+
+The config file has `[global]` and `[debug]` sections that control general operation; an optional
+section for the transport type chosen, currently none; and a section each for the sonar operations,
+controlling their cadence and operation in the same way as normal command line switches.  For the
+Sonar operations, the cadence setting is required for the operation to be run, the command will be
+run at a time that is zero mod the cadence.
+
+### `[global]` section
+
+```
+cluster = <canonical cluster name>
+role = node | master
+lockdir = <string>                              # default none
+```
+
+The `cluster` option is required, eg `fox.educloud.no`.
+
+The `role` determines how this daemon responds to control messages from a remote controller.  It
+must be defined.  Only the string values listed are accepted.  A `node` typically provides sample
+and sysinfo data only, a `master` often only slurm and cluster data.
+
+If there is a `lockdir` then a lockfile in that directory is acquired when the daemon runs and stays
+acquired for the daemon's lifetime.  If the daemon is reloaded by remote command the lock is
+relinquished temporarily (and the restarted config file may name a different lockdir).
+
+### `[sample]` section aka `[ps]` section
+
+```
+cadence = <duration value>
+exclude-system-jobs = <bool>                    # default true
+load = <bool>                                   # default true
+batchless = <bool>                              # default false
+exclude-users = <comma-separated strings>       # default []
+exclude-commands = <comma-separated strings>    # default []
+```
+
+These are the normal options for `sonar ps`, see the Sonar documentation.
+
+### `[sysinfo]` section
+
+```
+cadence = <duration value>
+on-startup = <bool>                             # default true
+```
+
+If `on-startup` is `true` then a sysinfo operation will be executed every time the daemon is
+started, in addition to according to the cadence.
+
+### `[jobs]` section aka `[slurm]` section
+
+```
+cadence = <duration value>
+window = <duration value>                       # default 2*cadence
+uncompleted = <bool>                            # default false
+```
+
+The `window` is the sacct time window used for looking for data.
+
+The `uncompleted` option, if true, triggers the inclusion of data about pending and running jobs.
+This will result in multiple transmissions of data for the same `(job_id,job_step)`, one at each
+sample point.  If a job stays in, say, the PENDING state for several sampling windows then multiple
+transmissions for the job in the PENDING state will be seen.
+
+### `[cluster]` section
+
+```
+cadence = <duration value>
+```
+
+### `[debug]` section
+
+```
+verbose = bool                                  # default false
+```
+
+Setting `verbose` to true will cause the daemon to print somewhat informative messages about what
+it's doing at important points during the run.
+
+## DATA MESSAGE FORMATS
+
+Data messages are sent to a topic with a key and a value.
+
+Data messages are sent from Sonar to the broker under topics `<cluster>.<data-type>` where `<cluster>`
+is as configured in the `[global]` section and `<data-type>` is `sample`, `sysinfo`, `job`, `cluster`.
+
+The key sent with a message is currently the name of the originating node, including when that node
+is a master node.
+
+The values sent with these messages are opaque.  They may be a JSON object (always new-format JSON,
+see [NEW-FORMAT.md](NEW-FORMAT.md)), compressed text, and/or otherwise transformed.  Currently there
+is no way of requesting anything other than JSON, and if there is compression it is applied
+transparently.
+
+When using the stdout sink, the printed data messages are JSON objects with "topic", "key",
+"client", and "value" members.
+
+## CONTROL MESSAGE FORMATS
+
+Control messages are sent to Sonar under topics `<cluster>.control.<role>` where `<cluster>` is as
+configured in the `[global]` section and `<role>` is `node` or `master`.  These will have key and
+value as follows (very much TBD):
+
+```
+  Key     Value      Meaning
+  ------- ---------- -------------------------------------------
+  exit    (none)     Terminate sonar immediately
+```
+
+Control messages may be delivered more than once - just a fact of life - but will be ignored if they
+are too old.
+
+TODO: It's quite possible that the key should be either the node name or the empty string, for
+messages directed at a specific node or at all, and that the command/argument should be in the
+value.

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -19,7 +19,24 @@ use crate::systemapi;
 
 use std::io;
 
-pub fn show_cluster(writer: &mut dyn io::Write, token: String, system: &dyn systemapi::SystemAPI) {
+#[cfg(feature = "daemon")]
+pub struct State<'a> {
+    system: &'a dyn systemapi::SystemAPI,
+    token: String,
+}
+
+#[cfg(feature = "daemon")]
+impl<'a> State<'a> {
+    pub fn new(system: &'a dyn systemapi::SystemAPI, token: String) -> State<'a> {
+        State { system, token }
+    }
+
+    pub fn run(&mut self, writer: &mut dyn io::Write) {
+        show_cluster(writer, self.system, self.token.clone())
+    }
+}
+
+pub fn show_cluster(writer: &mut dyn io::Write, system: &dyn systemapi::SystemAPI, token: String) {
     output::write_json(
         writer,
         &output::Value::O(match do_show_cluster(system, token.clone()) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,841 @@
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::len_zero)]
+
+// TODO in this file, all marked:
+//
+// Low pri
+//  - lock file
+//  - signal handling to deal properly with with lock file
+//  - reload config under signal + remote control (exiting and restarting via systemd is
+//    just fine for starters)
+//  - maybe pause / restart remote control
+//  - more flexible cadence computation
+//  - more test cases for the cadence computation
+
+// For documentation about configuration and message topics that are used, see ~/doc/HOWTO-DAEMON.md.
+
+// THREADS AND I/O
+//
+// The main thread of the daemon listens on a channel from which it reads events: alarms (for work
+// to do), signals (keyboard interrupts), and incoming messages (from some controlling agent).
+//
+// Signal handlers place signals in the daemon's channel as events.
+
+use crate::cluster;
+use crate::datasink::{DataSink, StdioSink};
+use crate::jobsapi;
+use crate::json_tags;
+use crate::ps;
+use crate::realsystem;
+use crate::slurmjobs;
+use crate::sysinfo;
+use crate::systemapi::SystemAPI;
+use crate::time::{unix_now, unix_time_components};
+
+use std::io::BufRead;
+use std::sync::mpsc;
+use std::thread;
+
+pub struct GlobalIni {
+    pub cluster: String,
+    pub role: String,
+    pub lockdir: Option<String>,
+}
+
+pub struct DebugIni {
+    pub verbose: bool,
+}
+
+pub struct SampleIni {
+    pub cadence: Option<Dur>,
+    pub exclude_system_jobs: bool,
+    pub load: bool,
+    pub batchless: bool,
+    pub exclude_commands: Vec<String>,
+    pub exclude_users: Vec<String>,
+}
+
+pub struct SysinfoIni {
+    pub on_startup: bool,
+    pub cadence: Option<Dur>,
+}
+
+pub struct JobsIni {
+    pub cadence: Option<Dur>,
+    pub window: Option<Dur>,
+    pub uncompleted: bool,
+}
+
+pub struct ClusterIni {
+    pub cadence: Option<Dur>,
+}
+
+pub struct Ini {
+    pub global: GlobalIni,
+    pub debug: DebugIni,
+    pub sample: SampleIni,
+    pub sysinfo: SysinfoIni,
+    pub jobs: JobsIni,
+    pub cluster: ClusterIni,
+}
+
+#[derive(Clone, Debug)]
+pub enum Operation {
+    Sample,
+    Sysinfo,
+    Jobs,
+    Cluster,
+    // Signals: signal code
+    #[allow(dead_code)]
+    Signal(i32),
+    // Control messages: key/value
+    #[allow(dead_code)]
+    Incoming(String, String),
+    // Unrecoverable errors on other threads: explanatory message
+    #[allow(dead_code)]
+    Fatal(String),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Dur {
+    Hours(u64),
+    Minutes(u64),
+    Seconds(u64),
+}
+
+#[allow(dead_code)]
+impl Dur {
+    pub fn to_seconds(self) -> u64 {
+        match self {
+            Dur::Hours(n) => n * 60 * 60,
+            Dur::Minutes(n) => n * 60,
+            Dur::Seconds(n) => n,
+        }
+    }
+
+    pub fn to_minutes(self) -> u64 {
+        match self {
+            Dur::Hours(n) => n * 60,
+            Dur::Minutes(n) => n,
+            Dur::Seconds(n) => (n + 59) / 60,
+        }
+    }
+}
+
+// The daemon_mode() should return under these circumstances *only*:
+//
+// - it fails to parse the ini file
+// - it fails to read any specified files
+// - it fails to acquire the lock file
+// - it fails to setup an interrupt handler
+// - an exit control message is received from the broker
+// - a signal is received from the OS or user that signifies an exit condition
+//
+// Other errors require threads to post messages back to the main thread.
+//
+// It is crucial that the system does not terminate suddenly once the lock file is held: we must
+// unwind properly and do what we can to relinquish the lock.
+
+pub fn daemon_mode(
+    config_file: &str,
+    mut system: realsystem::RealSystemBuilder,
+    force_slurm: bool,
+) -> Result<(), String> {
+    let ini = parse_config(config_file)?;
+
+    if ini.sample.cadence.is_some() {
+        system = system.with_jobmanager(Box::new(jobsapi::AnyJobManager::new(force_slurm)));
+    }
+
+    let system = system.with_cluster(&ini.global.cluster).freeze()?;
+    let hostname = system.get_hostname();
+    let api_token = "".to_string();
+
+    if ini.global.lockdir.is_some() {
+        // TODO: Acquire lockdir here
+        // TODO: Set up interrupt handling
+        todo!();
+    }
+
+    // For communicating with the main thread.  event_sender is used to send timer ticks (from timer
+    // threads), incoming messages (from the data sink), signals (from the signal handling thread),
+    // and errors (from anywhere); event_receiver receives those events in the main thread.
+    let (event_sender, event_receiver) = mpsc::channel();
+
+    // If sysinfo runs on startup then post a message to ourselves.  Should never fail.
+    if ini.sysinfo.cadence.is_some() && ini.sysinfo.on_startup {
+        let _ignored = event_sender.send(Operation::Sysinfo);
+    }
+
+    // Alarms for daemon operations - each alarm gets its own thread, wasteful but OK for the time
+    // being.  These will post the given events at the given cadences.
+    if let Some(c) = ini.sysinfo.cadence {
+        let sender = event_sender.clone();
+        thread::spawn(move || {
+            repeated_event(json_tags::DATA_TAG_SYSINFO, sender, Operation::Sysinfo, c);
+        });
+    }
+    if let Some(c) = ini.sample.cadence {
+        let sender = event_sender.clone();
+        thread::spawn(move || {
+            repeated_event(json_tags::DATA_TAG_SAMPLE, sender, Operation::Sample, c);
+        });
+    }
+    if let Some(c) = ini.jobs.cadence {
+        let sender = event_sender.clone();
+        thread::spawn(move || {
+            repeated_event(json_tags::DATA_TAG_JOBS, sender, Operation::Jobs, c);
+        });
+    }
+    if let Some(c) = ini.cluster.cadence {
+        let sender = event_sender.clone();
+        thread::spawn(move || {
+            repeated_event(json_tags::DATA_TAG_CLUSTER, sender, Operation::Cluster, c);
+        });
+    }
+
+    // At the moment, with the ini having no sections for data sinks, the only possible data sink is
+    // the stdio sink.
+    let data_sink: Box<dyn DataSink> = Box::new(StdioSink::new(
+        ini.global.cluster.clone() + "/" + &hostname,
+        event_sender,
+    ));
+
+    if ini.debug.verbose {
+        println!("Initialization succeeded");
+    }
+
+    let mut sample_extractor = ps::State::new(
+        &system,
+        &ps::PsOptions {
+            rollup: false,
+            min_cpu_percent: None,
+            min_mem_percent: None,
+            min_cpu_time: None,
+            exclude_system_jobs: ini.sample.exclude_system_jobs,
+            load: ini.sample.load,
+            exclude_users: ini.sample.exclude_users.clone(),
+            exclude_commands: ini.sample.exclude_commands.clone(),
+            lockdir: ini.global.lockdir.clone(),
+            new_json: true,
+            cpu_util: true,
+            token: api_token.clone(),
+        },
+    );
+
+    let mut sysinfo_extractor = sysinfo::State::new(&system, api_token.clone());
+
+    let mut cluster_extractor = cluster::State::new(&system, api_token.clone());
+
+    let mut slurm_extractor = slurmjobs::State::new(
+        ini.jobs.window.map(|c| c.to_minutes() as u32),
+        ini.jobs.uncompleted,
+        &system,
+        api_token.clone(),
+    );
+
+    let mut fatal_msg = "".to_string();
+    'messageloop: loop {
+        let mut output = Vec::new();
+
+        // Nobody gets to close this channel, so panic on error
+        let op = event_receiver.recv().expect("Event queue receive");
+
+        system.update_time();
+        let topic: &'static str;
+        match op {
+            Operation::Sample => {
+                if ini.debug.verbose {
+                    println!("Sample");
+                }
+                sample_extractor.run(&mut output);
+                topic = json_tags::DATA_TAG_SAMPLE;
+            }
+            Operation::Sysinfo => {
+                if ini.debug.verbose {
+                    println!("Sysinfo");
+                }
+                sysinfo_extractor.run(&mut output);
+                topic = json_tags::DATA_TAG_SYSINFO;
+            }
+            Operation::Jobs => {
+                if ini.debug.verbose {
+                    println!("Jobs");
+                }
+                slurm_extractor.run(&mut output);
+                topic = json_tags::DATA_TAG_JOBS;
+            }
+            Operation::Cluster => {
+                if ini.debug.verbose {
+                    println!("Cluster");
+                }
+                cluster_extractor.run(&mut output);
+                topic = json_tags::DATA_TAG_CLUSTER;
+            }
+            Operation::Signal(s) => {
+                if ini.debug.verbose {
+                    println!("signal {s}");
+                }
+                match s {
+                    libc::SIGINT | libc::SIGHUP => {
+                        break 'messageloop;
+                    }
+                    libc::SIGTERM => {
+                        // TODO: reload
+                        continue 'messageloop;
+                    }
+                    _ => {
+                        continue 'messageloop;
+                    }
+                }
+            }
+            Operation::Incoming(key, value) => {
+                if ini.debug.verbose {
+                    println!("Incoming");
+                }
+                // TODO: Maybe a reload function
+                // TODO: Maybe pause / restart functions
+                match (key.as_str(), value.as_str()) {
+                    ("exit", _) => {
+                        break 'messageloop;
+                    }
+                    _ => {}
+                }
+                continue 'messageloop;
+            }
+            Operation::Fatal(msg) => {
+                if ini.debug.verbose {
+                    println!("Fatal {msg}");
+                }
+                fatal_msg = msg;
+                break 'messageloop;
+            }
+        }
+
+        let topic = ini.global.cluster.clone() + "." + topic;
+        let key = hostname.clone();
+        let value = String::from_utf8_lossy(&output).to_string();
+
+        data_sink.post(topic, key, value);
+    }
+
+    data_sink.stop();
+
+    // Other threads will need to not panic when they are killed on shutdown, but otherwise there's
+    // nothing special to be done here for the repeater threads or even the signal processing
+    // thread.
+
+    if ini.global.lockdir.is_some() {
+        // TODO: Relinquish lockdir here
+        // TODO: Maybe tear down interrupt handling?
+        todo!();
+    }
+
+    if fatal_msg != "" {
+        Err(fatal_msg)
+    } else {
+        Ok(())
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Alarms and cadences.
+
+fn repeated_event(_whoami: &str, sender: mpsc::Sender<Operation>, op: Operation, cadence: Dur) {
+    let now = unix_now();
+    let first = time_at_next_cadence_point(now, cadence);
+    let initial_delay = first as i64 - now as i64;
+    if initial_delay > 0 {
+        thread::sleep(std::time::Duration::from_secs(initial_delay as u64));
+    }
+    let delay = cadence.to_seconds();
+    let mut count = 0u64;
+    loop {
+        // If the send fails then the main loop has closed the connection and this is our signal to
+        // shut down the thread.
+        if sender.send(op.clone()).is_err() {
+            break;
+        }
+
+        // It may be important to the back-end that events are triggered roughly at the expected
+        // time according to the cadence (certainly it was important for the initial back-end).
+        // Therefore we compute the next event point as the initial event point plus a multiple of
+        // the cadence.  This mostly removes the risk of getting out of sync with the desired
+        // cadence points.
+        //
+        // There should be no risk of wrapping around or overflowing here.  The product of count and
+        // delay is always the number of seconds since the first event.  2^64 seconds is nearly 6e11
+        // years.  The initial timestamp is some 32-bit value for the foreseeable future.
+
+        count += 1;
+        let next = first + count * delay;
+        let next_delay = next as i64 - unix_now() as i64;
+        if next_delay > 0 {
+            thread::sleep(std::time::Duration::from_secs(next_delay as u64));
+        }
+    }
+}
+
+// Round up `now` to the next multiple of `cadence`.  For example, if `cadence` is 5m then the value
+// returned represents the unix time at the next 5 minute mark; if `cadence` is 24h then the value
+// is the time at next midnight.  It's OK for this to be expensive (for now).  This can validly
+// return `now`.
+//
+// The many restrictions on cadences ensure that this rounding is well-defined and leads to
+// well-defined sample points across all nodes (that have sensibly synchronized clocks and are in
+// compatible time zones).
+//
+// Multi-day boundaries are a little tricky but we can use the next midnight s.t.  the number of
+// days evenly divides the day number.
+//
+// TODO: Some sensible cadences such as 90m aka 1h30m are not currently expressible.
+
+fn time_at_next_cadence_point(now: u64, cadence: Dur) -> u64 {
+    let (_, _, day, hour, minute, second) = unix_time_components(now);
+    now + match cadence {
+        Dur::Seconds(s) => s - second % s,
+        Dur::Minutes(m) => 60 * (m - minute % m) - second,
+        Dur::Hours(h) if h <= 24 => 60 * (60 * (h - hour % h) - minute) - second,
+        Dur::Hours(h) => {
+            let d = h / 24;
+            60 * (60 * (24 * (d - day % d) - hour) - minute) - second
+        }
+    }
+}
+
+#[test]
+pub fn test_cadence_computer() {
+    // TODO: Add some harder test cases
+
+    // 1740568588-2025-02-26T11:16:28
+    let now = 1740568588;
+
+    // next 15-second boundary
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Seconds(15)));
+    assert!(hour == 11);
+    assert!(minute == 16);
+    assert!(second == 30);
+
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now + 15, Dur::Seconds(15)));
+    assert!(hour == 11);
+    assert!(minute == 16);
+    assert!(second == 45);
+
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now + 30, Dur::Seconds(15)));
+    assert!(hour == 11);
+    assert!(minute == 17);
+    assert!(second == 00);
+
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now + 45, Dur::Seconds(15)));
+    assert!(hour == 11);
+    assert!(minute == 17);
+    assert!(second == 15);
+
+    // next 2-second boundary...
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Seconds(2)));
+    assert!(hour == 11);
+    assert!(minute == 16);
+    assert!(second == 30);
+
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now + 31, Dur::Seconds(2)));
+    println!("{hour} {minute} {second}");
+    assert!(hour == 11);
+    assert!(minute == 17);
+    assert!(second == 00);
+
+    // next 1-minute boundary
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Minutes(1)));
+    println!("{hour} {minute} {second}");
+    assert!(hour == 11);
+    assert!(minute == 17);
+    assert!(second == 00);
+
+    // next 5-minute boundary
+    let (year, month, day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Minutes(5)));
+    assert!(year == 2025);
+    assert!(month == 1);
+    assert!(day == 25);
+    assert!(hour == 11);
+    assert!(minute == 20);
+    assert!(second == 0);
+
+    // next 2-hour boundary
+    let (_year, _month, _day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Hours(2)));
+    assert!(hour == 12);
+    assert!(minute == 00);
+    assert!(second == 00);
+
+    // next 24-hour boundary is just next midnight
+    let (year, month, day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Hours(24)));
+    assert!(year == 2025);
+    assert!(month == 1);
+    assert!(day == 26);
+    assert!(hour == 00);
+    assert!(minute == 00);
+    assert!(second == 00);
+
+    let (year, month, day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Hours(48)));
+    assert!(year == 2025);
+    assert!(month == 1);
+    assert!(day == 26);
+    assert!(hour == 00);
+    assert!(minute == 00);
+    assert!(second == 00);
+
+    let (year, month, day, hour, minute, second) =
+        unix_time_components(time_at_next_cadence_point(now, Dur::Hours(72)));
+    //println!("72: {year} {month} {day} {hour} {minute} {second}");
+    assert!(year == 2025);
+    assert!(month == 1);
+    assert!(day == 27);
+    assert!(hour == 00);
+    assert!(minute == 00);
+    assert!(second == 00);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Yet another config file parser.
+
+fn parse_config(config_file: &str) -> Result<Ini, String> {
+    let mut ini = Ini {
+        global: GlobalIni {
+            cluster: "".to_string(),
+            role: "".to_string(),
+            lockdir: None,
+        },
+        debug: DebugIni { verbose: false },
+        sample: SampleIni {
+            cadence: None,
+            exclude_system_jobs: true,
+            load: true,
+            batchless: false,
+            exclude_commands: vec![],
+            exclude_users: vec![],
+        },
+        sysinfo: SysinfoIni {
+            on_startup: true,
+            cadence: None,
+        },
+        jobs: JobsIni {
+            cadence: None,
+            window: None,
+            uncompleted: false,
+        },
+        cluster: ClusterIni { cadence: None },
+    };
+
+    enum Section {
+        None,
+        Global,
+        Debug,
+        Sample,
+        Sysinfo,
+        Jobs,
+        Cluster,
+    }
+    let mut curr_section = Section::None;
+    let file = match std::fs::File::open(config_file) {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(format!("{e}"));
+        }
+    };
+    for l in std::io::BufReader::new(file).lines() {
+        let l = match l {
+            Ok(l) => l,
+            Err(e) => {
+                return Err(format!("{e}"));
+            }
+        };
+        if l.starts_with('#') {
+            continue;
+        }
+        let l = trim_ascii(&l);
+        if l.len() == 0 {
+            continue;
+        }
+        if l == "[global]" {
+            curr_section = Section::Global;
+            continue;
+        }
+        if l == "[debug]" {
+            curr_section = Section::Debug;
+            continue;
+        }
+        if l == "[ps]" || l == "[sample]" {
+            curr_section = Section::Sample;
+            continue;
+        }
+        if l == "[sysinfo]" {
+            curr_section = Section::Sysinfo;
+            continue;
+        }
+        if l == "[slurm]" || l == "[jobs]" {
+            curr_section = Section::Jobs;
+            continue;
+        }
+        if l == "[cluster]" {
+            curr_section = Section::Cluster;
+            continue;
+        }
+        if l.starts_with("[") {
+            return Err(format!("Unknown section {l}"));
+        }
+
+        let (name, value) = parse_setting(l)?;
+        match curr_section {
+            Section::None => return Err("Setting outside section".to_string()),
+            Section::Global => match name.as_str() {
+                "cluster" => {
+                    ini.global.cluster = value;
+                }
+                "role" => match value.as_str() {
+                    "node" | "master" => {
+                        ini.global.role = value;
+                    }
+                    _ => return Err(format!("Invalid global.role value `{value}`")),
+                },
+                "lockdir" => {
+                    ini.global.lockdir = Some(value);
+                }
+                _ => return Err(format!("Invalid [global] setting name `{name}`")),
+            },
+            Section::Debug => match name.as_str() {
+                "verbose" => {
+                    ini.debug.verbose = parse_bool(&value)?;
+                }
+                _ => return Err(format!("Invalid [debug] setting name `{name}`")),
+            },
+            Section::Sample => match name.as_str() {
+                "cadence" => {
+                    ini.sample.cadence = Some(parse_duration("sample.cadence", &value, false)?);
+                }
+                "exclude-system-jobs" => {
+                    ini.sample.exclude_system_jobs = parse_bool(&value)?;
+                }
+                "load" => {
+                    ini.sample.load = parse_bool(&value)?;
+                }
+                "exclude-users" => {
+                    ini.sample.exclude_users = parse_strings(&value)?;
+                }
+                "exclude-commands" => {
+                    ini.sample.exclude_commands = parse_strings(&value)?;
+                }
+                "batchless" => {
+                    ini.sample.batchless = parse_bool(&value)?;
+                }
+                _ => return Err(format!("Invalid [sample]/[ps] setting name `{name}`")),
+            },
+            Section::Sysinfo => match name.as_str() {
+                "on-startup" => {
+                    ini.sysinfo.on_startup = parse_bool(&value)?;
+                }
+                "cadence" => {
+                    ini.sysinfo.cadence = Some(parse_duration("sysinfo.cadence", &value, false)?);
+                }
+                _ => return Err(format!("Invalid [sysinfo] setting name `{name}`")),
+            },
+            Section::Jobs => match name.as_str() {
+                "cadence" => {
+                    let dur = parse_duration("jobs.cadence", &value, false)?;
+                    ini.jobs.cadence = Some(dur);
+                    if ini.jobs.window.is_none() {
+                        ini.jobs.window = Some(Dur::Seconds(2 * dur.to_seconds()));
+                    }
+                }
+                "window" => {
+                    ini.jobs.window = Some(parse_duration("jobs.window", &value, true)?);
+                }
+                "uncompleted" | "incomplete" => {
+                    ini.jobs.uncompleted = parse_bool(&value)?;
+                }
+                _ => return Err(format!("Invalid [jobs] setting name `{name}`")),
+            },
+            Section::Cluster => match name.as_str() {
+                "cadence" => {
+                    ini.cluster.cadence = Some(parse_duration("cluster.cadence", &value, false)?);
+                }
+                _ => return Err(format!("Invalid [cluster] setting name `{name}`")),
+            },
+        }
+    }
+
+    if ini.global.cluster == "" {
+        return Err("Missing global.cluster setting".to_string());
+    }
+    if ini.global.role == "" {
+        return Err("Missing global.role setting".to_string());
+    }
+
+    Ok(ini)
+}
+
+fn parse_setting(l: &str) -> Result<(String, String), String> {
+    if let Some((name, value)) = l.split_once('=') {
+        let name = trim_ascii(name);
+        // A little too lenient
+        for c in name.chars() {
+            if !(c >= 'A' && c <= 'Z'
+                || c >= 'a' && c <= 'z'
+                || c >= '0' && c <= '9'
+                || c == '-'
+                || c == '_')
+            {
+                return Err("Illegal character in name".to_string());
+            }
+        }
+        let value = trim_ascii(value);
+        if value == "" {
+            return Err("Empty string must be quoted".to_string());
+        }
+        let value = trim_quotes(value)?;
+        Ok((name.to_string(), value.to_string()))
+    } else {
+        Err("Illegal property definition".to_string())
+    }
+}
+
+fn parse_bool(l: &str) -> Result<bool, String> {
+    match l {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(format!("Invalid boolean value {l}")),
+    }
+}
+
+fn parse_duration(context: &str, l: &str, lenient: bool) -> Result<Dur, String> {
+    if let Some(hours) = l.strip_suffix(['h', 'H']) {
+        if let Ok(k) = hours.parse::<u64>() {
+            if k > 0 && (lenient || 24 % k == 0 || k % 24 == 0) {
+                return Ok(Dur::Hours(k));
+            }
+        }
+        return Err(format!("Bad duration in {context}"));
+    }
+    if let Some(minutes) = l.strip_suffix(['m', 'M']) {
+        if let Ok(k) = minutes.parse::<u64>() {
+            if k > 0 && (lenient || (k < 60 && 60 % k == 0)) {
+                return Ok(Dur::Minutes(k));
+            }
+        }
+        return Err(format!("Bad duration in {context}"));
+    }
+    if let Some(seconds) = l.strip_suffix(['s', 'S']) {
+        if let Ok(k) = seconds.parse::<u64>() {
+            if k > 0 && (lenient || (k < 60 && 60 % k == 0)) {
+                return Ok(Dur::Seconds(k));
+            }
+        }
+    }
+    Err(format!("Bad duration in {context}"))
+}
+
+fn parse_strings(l: &str) -> Result<Vec<String>, String> {
+    if l == "" {
+        Ok(vec![])
+    } else {
+        Ok(l.split(',').map(|x| x.to_string()).collect::<Vec<String>>())
+    }
+}
+
+fn trim_ascii(l: &str) -> &str {
+    // std::str::trim_ascii() is rust v1.80 or later, implement a simple one
+    let bs = l.as_bytes();
+    let mut first = 0;
+    while first < bs.len() && (bs[first] == b' ' || bs[first] == b'\t') {
+        first += 1;
+    }
+    if first == bs.len() {
+        return "";
+    }
+    let mut limit = bs.len();
+    while bs[limit - 1] == b' ' || bs[limit - 1] == b'\t' {
+        limit -= 1;
+    }
+    std::str::from_utf8(&bs[first..limit]).unwrap()
+}
+
+#[test]
+pub fn test_trim_ascii() {
+    assert!(trim_ascii(" abc ") == "abc");
+    assert!(trim_ascii("  ") == "");
+    assert!(trim_ascii("a b") == "a b");
+    assert!(trim_ascii("") == "");
+    assert!(trim_ascii(" \t abc\t \t") == "abc");
+}
+
+fn trim_quotes(l: &str) -> Result<&str, String> {
+    // Invariant: bs.len() > 0
+    let bs = l.as_bytes();
+    if bs[0] == b'\'' || bs[0] == b'"' || bs[0] == b'`' {
+        if bs.len() < 2 || bs[0] != bs[bs.len() - 1] {
+            Err("Mismatched quotes".to_string())
+        } else {
+            Ok(std::str::from_utf8(&bs[1..bs.len() - 1]).unwrap())
+        }
+    } else {
+        Ok(l)
+    }
+}
+
+#[test]
+pub fn test_trim_quotes() {
+    assert!(trim_quotes("abc").unwrap() == "abc");
+    assert!(trim_quotes("'abc'").unwrap() == "abc");
+    assert!(trim_quotes("`abc`").unwrap() == "abc");
+    assert!(trim_quotes("abc`").unwrap() == "abc`"); // Only leading quote strips the trailing one
+    assert!(trim_quotes("\"abc\"").unwrap() == "abc");
+    assert!(trim_quotes("'abc").is_err());
+    assert!(trim_quotes("'abc`").is_err());
+}
+
+#[test]
+pub fn test_parser() {
+    let (a, b) = parse_setting(" x-factor = 10 ").unwrap();
+    assert!(a == "x-factor");
+    assert!(b == "10");
+    let (a, b) = parse_setting("X_fact0r=`10 + 20`").unwrap();
+    assert!(a == "X_fact0r");
+    assert!(b == "10 + 20");
+    assert!(parse_bool("true") == Ok(true));
+    assert!(parse_bool("false") == Ok(false));
+    assert!(parse_strings("").unwrap().len() == 0);
+    assert!(parse_strings("a,b").unwrap().len() == 2);
+    assert!(parse_duration("", "30s", true).unwrap() == Dur::Seconds(30));
+    assert!(parse_duration("", "10m", true).unwrap() == Dur::Minutes(10));
+    assert!(parse_duration("", "6H", true).unwrap() == Dur::Hours(6));
+
+    assert!(parse_setting("zappa").is_err());
+    assert!(parse_setting("zappa = ").is_err());
+    assert!(parse_setting("zappa = `abracadabra").is_err());
+    assert!(parse_setting("zapp! = true").is_err());
+    assert!(parse_bool("tru").is_err());
+    assert!(parse_duration("", "35", true).is_err());
+    assert!(parse_duration("", "12m35s", true).is_err());
+    assert!(parse_duration("", "3H12M35X", true).is_err());
+
+    let ini = parse_config("src/testdata/daemon-stdio-config.txt").unwrap();
+    assert!(ini.global.cluster == "mlx.hpc.uio.no");
+    assert!(ini.global.role == "node");
+    assert!(ini.sample.cadence == Some(Dur::Minutes(5)));
+    assert!(ini.sample.batchless);
+    assert!(!ini.sample.load);
+    assert!(ini.sysinfo.cadence == Some(Dur::Hours(24)));
+    assert!(ini.jobs.cadence == Some(Dur::Hours(1)));
+    assert!(ini.jobs.window == Some(Dur::Minutes(90)));
+    // TODO: Test cluster
+}

--- a/src/datasink.rs
+++ b/src/datasink.rs
@@ -1,0 +1,69 @@
+use crate::daemon;
+
+use std::io;
+use std::sync::mpsc;
+use std::thread;
+
+// The DataSink hides the specific data sink we use.  It receives outgoing traffic by `post()` and
+// posts any incoming messages or errors on `sender`.  The sink may batch outgoing messages, and its
+// network connection - if there is one - may go up and down, and so on.
+
+pub trait DataSink {
+    // Queue the message for sending, to be sent within the sending window.
+    fn post(&self, topic: String, key: String, value: String);
+
+    // Stop the sink.
+    fn stop(&self);
+}
+
+// Trivial data sink.  This dumps the output as JSON on stdout, and reads command messages from
+// stdin, on the form /key\s+value/.
+
+pub struct StdioSink {
+    client_id: String,
+}
+
+impl StdioSink {
+    pub fn new(client_id: String, sender: mpsc::Sender<daemon::Operation>) -> StdioSink {
+        thread::spawn(move || {
+            control_message_reader(sender);
+        });
+        StdioSink { client_id }
+    }
+}
+
+impl DataSink for StdioSink {
+    fn post(&self, topic: String, key: String, value: String) {
+        println!(
+            "{{\"topic\":\"{topic}\",\n \"key\":\"{key}\",\n \"client\":\"{}\",\n \"value\":{value}}}",
+            self.client_id,
+        );
+    }
+
+    fn stop(&self) {
+        // TODO: This (maybe) needs to kill the stdin thread
+    }
+}
+
+fn control_message_reader(sender: mpsc::Sender<daemon::Operation>) {
+    for line in io::stdin().lines() {
+        match line {
+            Ok(s) => {
+                if let Some((a, b)) = s.trim().split_once([' ', '\t']) {
+                    if sender
+                        .send(daemon::Operation::Incoming(
+                            a.trim().to_string(),
+                            b.trim().to_string(),
+                        ))
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+            Err(_) => {
+                return;
+            }
+        }
+    }
+}

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -18,7 +18,7 @@ use std::thread;
 #[cfg(debug_assertions)]
 use std::time;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct PsOptions {
     pub rollup: bool,
     pub min_cpu_percent: Option<f64>,
@@ -32,6 +32,26 @@ pub struct PsOptions {
     pub load: bool,
     pub new_json: bool,
     pub cpu_util: bool,
+}
+
+#[cfg(feature = "daemon")]
+pub struct State<'a> {
+    system: &'a dyn systemapi::SystemAPI,
+    opts: PsOptions,
+}
+
+#[cfg(feature = "daemon")]
+impl<'a> State<'a> {
+    pub fn new(system: &'a dyn systemapi::SystemAPI, opts: &PsOptions) -> State<'a> {
+        State {
+            system,
+            opts: opts.clone(),
+        }
+    }
+
+    pub fn run(&mut self, writer: &mut dyn io::Write) {
+        do_create_snapshot(writer, self.system, &self.opts)
+    }
 }
 
 pub fn create_snapshot(

--- a/src/slurmjobs.rs
+++ b/src/slurmjobs.rs
@@ -2,6 +2,10 @@
 
 // Run sacct, extract output and reformat as CSV or JSON on stdout.
 
+#![allow(clippy::vec_box)]
+#![allow(clippy::len_zero)]
+#![allow(clippy::comparison_to_empty)]
+
 use crate::json_tags::*;
 use crate::nodelist;
 use crate::output;
@@ -16,7 +20,7 @@ use std::collections::HashSet;
 use std::io;
 
 // The job states we are interested in collecting information about, notably PENDING and RUNNING
-// are not here by default but will be added if the --deluge option is given.
+// are not here by default but will be added if the `uncompleted` flag is set.
 
 static SACCT_STATES: Lazy<Vec<&'static str>> = Lazy::new(|| {
     vec![
@@ -73,6 +77,99 @@ static SACCT_FIELDS: Lazy<Vec<&'static str>> = Lazy::new(|| {
     ]
 });
 
+// The State is an object that wraps the slurm job data extractor, potentially taking advantage of
+// repeated invocations to avoid overhead or sending redundant data.
+
+#[cfg(feature = "daemon")]
+pub struct State<'a> {
+    window: Option<u32>,
+    token: String,
+    uncompleted: bool,
+    system: &'a dyn systemapi::SystemAPI,
+}
+
+#[derive(Default, Clone)]
+struct JobAll {
+    job_id: u64,      // "true" job ID, see doc/NEW-FORMAT.md
+    job_step: String, // "true" job step, ditto
+    job_name: String,
+    job_state: String,
+    array_job_id: u64,
+    array_task_id: u64,
+    het_job_id: u64,
+    het_job_offset: u64,
+    user_name: String,
+    account: String,
+    submit_time: String,
+    time_limit: u64,
+    partition: String,
+    reservation: String,
+    nodes: Vec<String>,
+    priority: u64,
+    distribution: String,
+    gres_detail: String,
+    requested_cpus: u64,
+    minimum_cpus_per_node: u64,
+    requested_memory_per_node: u64,
+    requested_node_count: u64,
+    start_time: String,
+    suspend_time: u64,
+    end_time: String,
+    exit_code: u64,
+    sacct_min_cpu: u64,
+    sacct_alloc_tres: String,
+    sacct_ave_cpu: u64,
+    sacct_ave_disk_read: u64,
+    sacct_ave_disk_write: u64,
+    sacct_ave_rss: u64,
+    sacct_ave_vmsize: u64,
+    sacct_elapsed_raw: u64,
+    sacct_system_cpu: u64,
+    sacct_user_cpu: u64,
+    sacct_max_rss: u64,
+    sacct_max_vmsize: u64,
+}
+
+#[cfg(feature = "daemon")]
+impl<'a> State<'a> {
+    pub fn new(
+        window: Option<u32>, // Minutes
+        uncompleted: bool,
+        system: &'a dyn systemapi::SystemAPI,
+        token: String,
+    ) -> State<'a> {
+        State {
+            window,
+            token,
+            uncompleted,
+            system,
+        }
+    }
+
+    pub fn run(&mut self, writer: &mut dyn io::Write) {
+        match collect_sacct_jobs_newfmt(self.system, &self.window, &None, self.uncompleted) {
+            Ok(jobs) => {
+                // This will push out a record even if the jobs array is empty.  This is probably
+                // the right thing, it serves as a heartbeat.
+                let mut envelope = output::newfmt_envelope(self.system, self.token.clone(), &[]);
+                let (mut data, mut attrs) = output::newfmt_data(self.system, DATA_TAG_JOBS);
+                attrs.push_a(JOBS_ATTRIBUTES_SLURM_JOBS, render_jobs_newfmt(jobs));
+                data.push_o(JOBS_DATA_ATTRIBUTES, attrs);
+                envelope.push_o(JOBS_ENVELOPE_DATA, data);
+                output::write_json(writer, &output::Value::O(envelope));
+            }
+            Err(error) => {
+                let mut envelope = output::newfmt_envelope(self.system, self.token.clone(), &[]);
+                envelope.push_a(
+                    JOBS_ENVELOPE_ERRORS,
+                    output::newfmt_one_error(self.system, error),
+                );
+                output::write_json(writer, &output::Value::O(envelope));
+            }
+        }
+    }
+}
+
 // Default sacct reporting window.  Note this value is baked into the help message in main.rs too.
 const DEFAULT_WINDOW: u32 = 90;
 
@@ -83,124 +180,405 @@ pub fn show_slurm_jobs(
     writer: &mut dyn io::Write,
     window: &Option<u32>,
     span: &Option<String>,
-    deluge: bool,
+    uncompleted: bool,
     system: &dyn systemapi::SystemAPI,
     token: String,
     new_json: bool,
 ) {
-    let embed_envelope = !new_json;
-    match collect_sacct_jobs(system, window, span, deluge, embed_envelope) {
+    if new_json {
+        show_slurm_jobs_newfmt(writer, window, span, uncompleted, system, token);
+    } else {
+        show_slurm_jobs_oldfmt(writer, window, span, system);
+    }
+}
+
+pub fn show_slurm_jobs_newfmt(
+    writer: &mut dyn io::Write,
+    window: &Option<u32>,
+    span: &Option<String>,
+    uncompleted: bool,
+    system: &dyn systemapi::SystemAPI,
+    token: String,
+) {
+    match collect_sacct_jobs_newfmt(system, window, span, uncompleted) {
         Ok(jobs) => {
-            if new_json {
-                let mut envelope = output::newfmt_envelope(system, token, &[]);
-                let (mut data, mut attrs) = output::newfmt_data(system, DATA_TAG_JOBS);
-                attrs.push_a(JOBS_ATTRIBUTES_SLURM_JOBS, jobs);
-                data.push_o(JOBS_DATA_ATTRIBUTES, attrs);
-                envelope.push_o(JOBS_ENVELOPE_DATA, data);
-                output::write_json(writer, &output::Value::O(envelope));
-            } else {
-                for i in 0..jobs.len() {
-                    output::write_csv(writer, jobs.at(i));
-                }
-            }
+            let mut envelope = output::newfmt_envelope(system, token, &[]);
+            let (mut data, mut attrs) = output::newfmt_data(system, DATA_TAG_JOBS);
+            attrs.push_a(JOBS_ATTRIBUTES_SLURM_JOBS, render_jobs_newfmt(jobs));
+            data.push_o(JOBS_DATA_ATTRIBUTES, attrs);
+            envelope.push_o(JOBS_ENVELOPE_DATA, data);
+            output::write_json(writer, &output::Value::O(envelope));
         }
         Err(error) => {
-            if new_json {
-                let mut envelope = output::newfmt_envelope(system, token, &[]);
-                envelope.push_a(
-                    JOBS_ENVELOPE_ERRORS,
-                    output::newfmt_one_error(system, error),
-                );
-                output::write_json(writer, &output::Value::O(envelope));
-            } else {
-                //+ignore-strings
-                let mut envelope = output::Object::new();
-                envelope.push_s("v", VERSION.to_string());
-                envelope.push_s("error", error);
-                envelope.push_s("timestamp", system.get_timestamp());
-                output::write_csv(writer, &output::Value::O(envelope));
-                //-ignore-strings
-            }
+            let mut envelope = output::newfmt_envelope(system, token, &[]);
+            envelope.push_a(
+                JOBS_ENVELOPE_ERRORS,
+                output::newfmt_one_error(system, error),
+            );
+            output::write_json(writer, &output::Value::O(envelope));
         }
     }
 }
 
-// Run sacct, parse and collect data, and place in an array of jobs for output - it's the same array
-// for the old and new formats.
-//
-// However, in the old "flat" CSV format, the "envelope" data (version, timestamp, error) are
-// embedded in each record.  In collect_jobs() we only insert non-exceptional data, any errors are
-// inserted into the first record before formatting, if they occur.
-
-fn collect_sacct_jobs(
+fn collect_sacct_jobs_newfmt(
     system: &dyn systemapi::SystemAPI,
     window: &Option<u32>,
     span: &Option<String>,
-    deluge: bool,
-    embed_envelope: bool,
-) -> Result<output::Array, String> {
-    // Parse the options to compute the time range to pass to sacct.
-    let (from, to) = if let Some(s) = span {
-        let components = s.split(',').collect::<Vec<&str>>();
-        if components.len() != 2 || !check_ymd(components[0]) || !check_ymd(components[1]) {
-            return Err(format!("Bad --span: {}", s));
-        }
-        (components[0].to_string(), components[1].to_string())
-    } else {
-        let mut minutes = DEFAULT_WINDOW;
-        if let Some(w) = window {
-            minutes = *w;
-        }
-        (format!("now-{minutes}minutes"), "now".to_string())
-    };
+    uncompleted: bool,
+) -> Result<Vec<Box<JobAll>>, String> {
+    let local = time::now_local();
+    let sacct_output = run_sacct(system, window, span, uncompleted)?;
+    Ok(parse_sacct_jobs_newfmt(&sacct_output, &local))
+}
 
-    // Run sacct and parse the output.
-    let mut states = SACCT_STATES.clone();
-    if deluge {
-        states.push("PENDING");
-        states.push("RUNNING");
-    }
-    match system.run_sacct(&states, &SACCT_FIELDS, &from, &to) {
-        Ok(sacct_output) => {
-            let local = time::now_local();
-            if embed_envelope {
-                Ok(parse_sacct_jobs_oldfmt(&sacct_output, &local))
-            } else {
-                Ok(parse_sacct_jobs_newfmt(&sacct_output, &local))
+fn parse_sacct_jobs_newfmt(sacct_output: &str, local: &libc::tm) -> Vec<Box<JobAll>> {
+    let mut jobs = vec![];
+    for line in sacct_output.lines() {
+        // There are ways of making this table-driven but none that are not complicated.
+        let fieldvals = compute_field_values(line);
+        let mut output_line = Box::new(JobAll {
+            ..Default::default()
+        });
+        for (i, field) in SACCT_FIELDS.iter().enumerate() {
+            // Ideally keep these in the order of the SACCT_FIELDS array, but I've pushed all the
+            // cases for the sacct object to the end.
+            match *field {
+                "JobID" => {
+                    // The format here is (\d+)(?:([.+])(\d+)(?:\.(.*)) where $1 is the job ID, $2
+                    // is the separator, $3 is the task/offset ID, and $4 is the step name.  The
+                    // separator gives us the job type and if not a normal job gives us the array or
+                    // het job ID and task or offset values.
+                    if let Some((id, task)) = fieldvals[i].split_once('_') {
+                        output_line.array_job_id = parse_uint(id);
+                        let task = if let Some((task_id, _)) = task.split_once('.') {
+                            task_id
+                        } else {
+                            task
+                        };
+                        output_line.array_task_id = parse_uint(task);
+                    } else if let Some((id, offset)) = fieldvals[i].split_once('+') {
+                        output_line.het_job_id = parse_uint(id);
+                        let offset = if let Some((offset_id, _)) = offset.split_once('.') {
+                            offset_id
+                        } else {
+                            offset
+                        };
+                        output_line.het_job_offset = parse_uint(offset);
+                    }
+                }
+                "JobIDRaw" => {
+                    if let Some((id, step)) = fieldvals[i].split_once('.') {
+                        output_line.job_id = parse_uint(id);
+                        output_line.job_step = step.to_string();
+                    } else {
+                        output_line.job_id = parse_uint(&fieldvals[i]);
+                    }
+                }
+                "User" => {
+                    // User is empty for administrative records
+                    output_line.user_name = fieldvals[i].clone();
+                }
+                "Account" => {
+                    output_line.account = fieldvals[i].clone();
+                }
+                "State" => {
+                    output_line.job_state = fieldvals[i].clone();
+                }
+                "Start" => {
+                    output_line.start_time = parse_date(&fieldvals[i], local);
+                }
+                "End" => {
+                    output_line.end_time = parse_date(&fieldvals[i], local);
+                }
+                "ExitCode" => {
+                    if fieldvals[i] != "" {
+                        // The format is code:signal
+                        if let Some((code, _signal)) = fieldvals[i].split_once(':') {
+                            output_line.exit_code = parse_uint(code);
+                        }
+                    }
+                }
+                "Layout" => {
+                    output_line.distribution = fieldvals[i].to_string();
+                }
+                "ReqCPUS" => {
+                    output_line.requested_cpus = parse_uint(&fieldvals[i]);
+                }
+                "ReqMem" => {
+                    output_line.requested_memory_per_node = parse_uint(&fieldvals[i]);
+                }
+                "ReqNodes" => {
+                    output_line.requested_node_count = parse_uint(&fieldvals[i]);
+                }
+                "Reservation" => {
+                    output_line.reservation = fieldvals[i].clone();
+                }
+                "Submit" => {
+                    output_line.submit_time = parse_date(&fieldvals[i], local);
+                }
+                "Suspended" => {
+                    output_line.suspend_time = parse_duration(&fieldvals[i]);
+                }
+                "TimelimitRaw" => {
+                    output_line.time_limit = match fieldvals[i].as_str() {
+                        "UNLIMITED" => EXTENDED_UINT_INFINITE,
+                        "Partition_limit" => EXTENDED_UINT_UNSET,
+                        limit => parse_uint_full(limit, 60, EXTENDED_UINT_BASE),
+                    };
+                }
+                "NodeList" => {
+                    if fieldvals[i] != "" {
+                        if let Ok(nodes) = nodelist::parse(&fieldvals[i]) {
+                            output_line.nodes = nodes;
+                        }
+                    }
+                }
+                "Partition" => {
+                    output_line.partition = fieldvals[i].clone();
+                }
+                "Priority" => {
+                    output_line.priority = parse_uint_full(&fieldvals[i], 1, EXTENDED_UINT_BASE);
+                }
+                "JobName" => {
+                    output_line.job_name = fieldvals[i].clone();
+                }
+
+                "AveDiskRead" => {
+                    output_line.sacct_ave_disk_read = parse_volume(&fieldvals[i]);
+                }
+                "AveDiskWrite" => {
+                    output_line.sacct_ave_disk_write = parse_volume(&fieldvals[i]);
+                }
+                "AveRSS" => {
+                    output_line.sacct_ave_rss = parse_volume(&fieldvals[i]);
+                }
+                "AveVMSize" => {
+                    output_line.sacct_ave_vmsize = parse_volume(&fieldvals[i]);
+                }
+                "MaxRSS" => {
+                    output_line.sacct_max_rss = parse_volume(&fieldvals[i]);
+                }
+                "MaxVMSize" => {
+                    output_line.sacct_max_vmsize = parse_volume(&fieldvals[i]);
+                }
+                "AveCPU" => {
+                    output_line.sacct_ave_cpu = parse_duration(&fieldvals[i]);
+                }
+                "MinCPU" => {
+                    output_line.sacct_min_cpu = parse_duration(&fieldvals[i]);
+                }
+                "UserCPU" => {
+                    output_line.sacct_user_cpu = parse_duration(&fieldvals[i]);
+                }
+                "SystemCPU" => {
+                    output_line.sacct_system_cpu = parse_duration(&fieldvals[i]);
+                }
+                "ElapsedRaw" => {
+                    output_line.sacct_elapsed_raw = parse_uint(&fieldvals[i]);
+                }
+                "AllocTRES" => {
+                    output_line.sacct_alloc_tres = fieldvals[i].clone();
+                }
+                _ => {
+                    panic!("Bad field name {}", *field);
+                }
             }
         }
-        Err(s) => Err(s),
+        jobs.push(output_line);
+    }
+    jobs
+}
+
+fn parse_uint(val: &str) -> u64 {
+    parse_uint_full(val, 1, 0)
+}
+
+fn parse_uint_full(val: &str, scale: u64, bias: u64) -> u64 {
+    if val != "" {
+        match val.parse::<u64>() {
+            Ok(n) => {
+                if n != 0 || bias != 0 {
+                    bias + n * scale
+                } else {
+                    0
+                }
+            }
+            Err(_) => 0,
+        }
+    } else {
+        0
     }
 }
 
-fn check_ymd(s: &str) -> bool {
-    let mut k = 0;
-    for f in s.split('-') {
-        k += 1;
-        if f.parse::<u32>().is_err() {
-            return false;
+fn parse_date(val: &str, local: &libc::tm) -> String {
+    if val != "" && val != "Unknown" {
+        // Reformat timestamps.  The slurm date format is localtime without a time zone offset.
+        // This is bound to lead to problems eventually, so reformat.  If parsing fails, just
+        // transmit the date and let the consumer deal with it.
+        if let Ok(mut t) = time::parse_date_and_time_no_tzo(val) {
+            t.tm_gmtoff = local.tm_gmtoff;
+            t.tm_isdst = local.tm_isdst;
+            // If t.tm_zone is not null then it must point to static data, so
+            // copy it just to be safe.
+            t.tm_zone = local.tm_zone;
+            return time::format_iso8601(&t).to_string();
         }
     }
-    k == 3
+    "".to_string()
 }
 
-fn compute_field_values(line: &str) -> Vec<String> {
-    let mut field_store = line.split('|').collect::<Vec<&str>>();
+fn parse_duration(mut val: &str) -> u64 {
+    // [DD-[hh:]]mm:ss
+    let days = if let Some((dd, rest)) = val.split_once('-') {
+        if let Ok(n) = dd.parse::<u64>() {
+            val = rest;
+            n
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+    let mut elts = val.split(':').collect::<Vec<&str>>();
+    let mut hours = 0;
+    if elts.len() == 3 {
+        if let Ok(n) = elts[0].parse::<u64>() {
+            elts.remove(0);
+            hours = n;
+        }
+    }
+    if elts.len() == 2 {
+        let minutes = elts[0].parse::<u64>().unwrap_or(0);
+        let seconds = elts[1].parse::<u64>().unwrap_or(0);
+        days * (24 * 60 * 60) + hours * (60 * 60) + minutes * 60 + seconds
+    } else {
+        0
+    }
+}
 
-    // If there are more fields than field names then that's because the job name
-    // contains `|`.  The JobName field always comes last.  Catenate excess fields until
-    // we have the same number of fields and names.  (Could just ignore excess fields
-    // instead.)
-    let n = SACCT_FIELDS.len();
-    let jobname = field_store[n - 1..].join("");
-    field_store[n - 1] = &jobname;
-    field_store[..n]
-        .iter()
-        .map(|x| x.to_string())
-        .collect::<Vec<String>>()
+fn parse_volume(val: &str) -> u64 {
+    if val != "" {
+        let (val, _scale) = if let Some(suffix) = val.strip_suffix('K') {
+            (suffix, 1024)
+        } else if let Some(suffix) = val.strip_suffix('M') {
+            (suffix, 1024 * 1024)
+        } else if let Some(suffix) = val.strip_suffix('G') {
+            (suffix, 1024 * 1024 * 1024)
+        } else {
+            (val, 1)
+        };
+        val.parse::<u64>().unwrap_or(0)
+    } else {
+        0
+    }
+}
+
+fn render_jobs_newfmt(jobs: Vec<Box<JobAll>>) -> output::Array {
+    let mut a = output::Array::new();
+    for j in jobs {
+        let mut o = output::Object::new();
+        push_uint(&mut o, SLURM_JOB_JOB_ID, j.job_id);
+        push_string(&mut o, SLURM_JOB_JOB_STEP, j.job_step);
+        push_string_full(&mut o, SLURM_JOB_JOB_NAME, j.job_name, false);
+        push_string(&mut o, SLURM_JOB_JOB_STATE, j.job_state);
+        push_uint(&mut o, SLURM_JOB_ARRAY_JOB_ID, j.array_job_id);
+        push_uint(&mut o, SLURM_JOB_ARRAY_TASK_ID, j.array_task_id);
+        push_uint(&mut o, SLURM_JOB_HET_JOB_ID, j.het_job_id);
+        push_uint(&mut o, SLURM_JOB_HET_JOB_OFFSET, j.het_job_offset);
+        push_string_full(&mut o, SLURM_JOB_USER_NAME, j.user_name, false);
+        push_string_full(&mut o, SLURM_JOB_ACCOUNT, j.account, false);
+        push_string(&mut o, SLURM_JOB_SUBMIT_TIME, j.submit_time);
+        push_uint(&mut o, SLURM_JOB_TIMELIMIT, j.time_limit);
+        push_string(&mut o, SLURM_JOB_PARTITION, j.partition);
+        push_string_full(&mut o, SLURM_JOB_RESERVATION, j.reservation, false);
+        if j.nodes.len() > 0 {
+            let mut ns = output::Array::new();
+            for n in j.nodes {
+                ns.push_s(n);
+            }
+            o.push_a(SLURM_JOB_NODE_LIST, ns);
+        }
+        push_uint(&mut o, SLURM_JOB_PRIORITY, j.priority);
+        push_string(&mut o, SLURM_JOB_LAYOUT, j.distribution);
+        push_string(&mut o, SLURM_JOB_GRESDETAIL, j.gres_detail);
+        push_uint(&mut o, SLURM_JOB_REQ_CPUS, j.requested_cpus);
+        push_uint(&mut o, SLURM_JOB_MIN_CPUSPER_NODE, j.minimum_cpus_per_node);
+        push_uint(&mut o, SLURM_JOB_REQ_MEMORY_PER_NODE, j.requested_memory_per_node);
+        push_uint(&mut o, SLURM_JOB_REQ_NODES, j.requested_node_count);
+        push_string(&mut o, SLURM_JOB_START, j.start_time);
+        push_uint(&mut o, SLURM_JOB_SUSPENDED, j.suspend_time);
+        push_string(&mut o, SLURM_JOB_END, j.end_time);
+        push_uint(&mut o, SLURM_JOB_EXIT_CODE, j.exit_code);
+        let mut s = output::Object::new();
+        push_uint(&mut s, SACCT_DATA_MIN_CPU, j.sacct_min_cpu);
+        push_string(&mut s, SACCT_DATA_ALLOC_TRES, j.sacct_alloc_tres);
+        push_uint(&mut s, SACCT_DATA_AVE_CPU, j.sacct_ave_cpu);
+        push_uint(&mut s, SACCT_DATA_AVE_DISK_READ, j.sacct_ave_disk_read);
+        push_uint(&mut s, SACCT_DATA_AVE_DISK_WRITE, j.sacct_ave_disk_write);
+        push_uint(&mut s, SACCT_DATA_AVE_RSS, j.sacct_ave_rss);
+        push_uint(&mut s, SACCT_DATA_AVE_VMSIZE, j.sacct_ave_vmsize);
+        push_uint(&mut s, SACCT_DATA_ELAPSED_RAW, j.sacct_elapsed_raw);
+        push_uint(&mut s, SACCT_DATA_SYSTEM_CPU, j.sacct_system_cpu);
+        push_uint(&mut s, SACCT_DATA_USER_CPU, j.sacct_user_cpu);
+        push_uint(&mut s, SACCT_DATA_MAX_RSS, j.sacct_max_rss);
+        push_uint(&mut s, SACCT_DATA_MAX_VMSIZE, j.sacct_max_vmsize);
+        if !s.is_empty() {
+            o.push_o(SLURM_JOB_SACCT, s)
+        }
+        a.push_o(o);
+    }
+    a
+}
+
+fn push_uint(o: &mut output::Object, k: &str, v: u64) {
+    if v != 0 {
+        o.push_u(k, v);
+    }
+}
+
+fn push_string(o: &mut output::Object, k: &str, v: String) {
+    push_string_full(o, k, v, true);
+}
+
+fn push_string_full(o: &mut output::Object, k: &str, v: String, filter_unknown: bool) {
+    if v != "" && (v != "Unknown" || filter_unknown) {
+        o.push_s(k, v);
+    }
 }
 
 //+ignore-strings
+pub fn show_slurm_jobs_oldfmt(
+    writer: &mut dyn io::Write,
+    window: &Option<u32>,
+    span: &Option<String>,
+    system: &dyn systemapi::SystemAPI,
+) {
+    match collect_sacct_jobs_oldfmt(system, window, span) {
+        Ok(jobs) => {
+            for i in 0..jobs.len() {
+                output::write_csv(writer, jobs.at(i));
+            }
+        }
+        Err(error) => {
+            let mut envelope = output::Object::new();
+            envelope.push_s("v", VERSION.to_string());
+            envelope.push_s("error", error);
+            envelope.push_s("timestamp", system.get_timestamp());
+            output::write_csv(writer, &output::Value::O(envelope));
+        }
+    }
+}
+
+fn collect_sacct_jobs_oldfmt(
+    system: &dyn systemapi::SystemAPI,
+    window: &Option<u32>,
+    span: &Option<String>,
+) -> Result<output::Array, String> {
+    let local = time::now_local();
+    let sacct_output = run_sacct(system, window, span, false)?;
+    Ok(parse_sacct_jobs_oldfmt(&sacct_output, &local))
+}
+
 fn parse_sacct_jobs_oldfmt(sacct_output: &str, local: &libc::tm) -> output::Array {
     // Fields that are dates that may be reinterpreted before transmission.
     let date_fields = HashSet::from(["Start", "End", "Submit"]);
@@ -248,290 +626,59 @@ fn parse_sacct_jobs_oldfmt(sacct_output: &str, local: &libc::tm) -> output::Arra
 }
 //-ignore-strings
 
-fn parse_sacct_jobs_newfmt(sacct_output: &str, local: &libc::tm) -> output::Array {
-    let mut jobs = output::Array::new();
-    for line in sacct_output.lines() {
-        // There are ways of making this table-driven but none that are not complicated.
-        let fieldvals = compute_field_values(line);
-        let mut output_line = output::Object::new();
-        let mut sacct = output::Object::new();
-        for (i, field) in SACCT_FIELDS.iter().enumerate() {
-            // Ideally keep these in the order of the SACCT_FIELDS array, but I've pushed all the
-            // cases for the sacct object to the end.
-            match *field {
-                "JobID" => {
-                    // The format here is (\d+)(?:([.+])(\d+)(?:\.(.*)) where $1 is the job ID, $2
-                    // is the separator, $3 is the task/offset ID, and $4 is the step name.  The
-                    // separator gives us the job type and if not a normal job gives us the array or
-                    // het job ID and task or offset values.
-                    if let Some((id, task)) = fieldvals[i].split_once('_') {
-                        push_uint(&mut output_line, SLURM_JOB_ARRAY_JOB_ID, id);
-                        let task = if let Some((task_id, _)) = task.split_once('.') {
-                            task_id
-                        } else {
-                            task
-                        };
-                        push_uint(&mut output_line, SLURM_JOB_ARRAY_TASK_ID, task);
-                    } else if let Some((id, offset)) = fieldvals[i].split_once('+') {
-                        push_uint(&mut output_line, SLURM_JOB_HET_JOB_ID, id);
-                        let offset = if let Some((offset_id, _)) = offset.split_once('.') {
-                            offset_id
-                        } else {
-                            offset
-                        };
-                        push_uint(&mut output_line, SLURM_JOB_HET_JOB_OFFSET, offset);
-                    }
-                }
-                "JobIDRaw" => {
-                    if let Some((id, step)) = fieldvals[i].split_once('.') {
-                        push_uint(&mut output_line, SLURM_JOB_JOB_ID, id);
-                        push_string(&mut output_line, SLURM_JOB_JOB_STEP, step);
-                    } else {
-                        push_uint(&mut output_line, SLURM_JOB_JOB_ID, &fieldvals[i]);
-                    }
-                }
-                "User" => {
-                    // User is empty for administrative records
-                    push_string(&mut output_line, SLURM_JOB_USER_NAME, &fieldvals[i]);
-                }
-                "Account" => {
-                    output_line.push_s(SLURM_JOB_ACCOUNT, fieldvals[i].clone());
-                }
-                "State" => {
-                    output_line.push_s(SLURM_JOB_JOB_STATE, fieldvals[i].clone());
-                }
-                "Start" => {
-                    push_date(&mut output_line, SLURM_JOB_START, &fieldvals[i], local);
-                }
-                "End" => {
-                    push_date(&mut output_line, SLURM_JOB_END, &fieldvals[i], local);
-                }
-                "ExitCode" => {
-                    if fieldvals[i] != "" {
-                        // The format is code:signal
-                        if let Some((code, _signal)) = fieldvals[i].split_once(':') {
-                            push_uint(&mut output_line, SLURM_JOB_EXIT_CODE, code);
-                        }
-                    }
-                }
-                "Layout" => {
-                    push_string(&mut output_line, SLURM_JOB_LAYOUT, &fieldvals[i]);
-                }
-                "ReqCPUS" => {
-                    push_uint(&mut output_line, SLURM_JOB_REQ_CPUS, &fieldvals[i]);
-                }
-                "ReqMem" => {
-                    push_uint(
-                        &mut output_line,
-                        SLURM_JOB_REQ_MEMORY_PER_NODE,
-                        &fieldvals[i],
-                    );
-                }
-                "ReqNodes" => {
-                    push_uint(&mut output_line, SLURM_JOB_REQ_NODES, &fieldvals[i]);
-                }
-                "Reservation" => {
-                    if fieldvals[i] != "" {
-                        output_line.push_s(SLURM_JOB_RESERVATION, fieldvals[i].clone());
-                    }
-                }
-                "Submit" => {
-                    push_date(
-                        &mut output_line,
-                        SLURM_JOB_SUBMIT_TIME,
-                        &fieldvals[i],
-                        local,
-                    );
-                }
-                "Suspended" => {
-                    push_duration(&mut output_line, SLURM_JOB_SUSPENDED, &fieldvals[i]);
-                }
-                "TimelimitRaw" => {
-                    // Just make sure this name is referenced
-                    assert!(EXTENDED_UINT_UNSET == 0);
-                    if fieldvals[i] == "UNLIMITED" {
-                        output_line.push_u(SLURM_JOB_TIMELIMIT, EXTENDED_UINT_INFINITE);
-                    } else if fieldvals[i] != "Partition_limit" {
-                        push_uint_full(
-                            &mut output_line,
-                            SLURM_JOB_TIMELIMIT,
-                            &fieldvals[i],
-                            60,
-                            EXTENDED_UINT_BASE,
-                            false,
-                        );
-                    }
-                }
-                "NodeList" => {
-                    if fieldvals[i] != "" {
-                        if let Ok(nodes) = nodelist::parse_and_render(&fieldvals[i]) {
-                            output_line.push_a(SLURM_JOB_NODE_LIST, nodes);
-                        }
-                    }
-                }
-                "Partition" => {
-                    push_string(&mut output_line, SLURM_JOB_PARTITION, &fieldvals[i]);
-                }
-                "Priority" => {
-                    push_uint_full(
-                        &mut output_line,
-                        SLURM_JOB_PRIORITY,
-                        &fieldvals[i],
-                        1,
-                        EXTENDED_UINT_BASE,
-                        false,
-                    );
-                }
-                "JobName" => {
-                    output_line.push_s(SLURM_JOB_JOB_NAME, fieldvals[i].clone());
-                }
+fn compute_field_values(line: &str) -> Vec<String> {
+    let mut field_store = line.split('|').collect::<Vec<&str>>();
 
-                // Sacct fields
-                "AveDiskRead" | "AveDiskWrite" | "AveRSS" | "AveVMSize" | "MaxRSS"
-                | "MaxVMSize" => {
-                    // NOTE - tags are the same as the fields
-                    assert!(SACCT_DATA_AVE_DISK_READ == "AveDiskRead");
-                    assert!(SACCT_DATA_AVE_DISK_WRITE == "AveDiskWrite");
-                    assert!(SACCT_DATA_AVE_RSS == "AveRSS");
-                    assert!(SACCT_DATA_AVE_VMSIZE == "AveVMSize");
-                    assert!(SACCT_DATA_MAX_RSS == "MaxRSS");
-                    assert!(SACCT_DATA_MAX_VMSIZE == "MaxVMSize");
-                    push_volume(&mut sacct, field, &fieldvals[i]);
-                }
-                "AveCPU" | "MinCPU" | "UserCPU" | "SystemCPU" => {
-                    // NOTE - tags are the same as the fields
-                    assert!(SACCT_DATA_AVE_CPU == "AveCPU");
-                    assert!(SACCT_DATA_MIN_CPU == "MinCPU");
-                    assert!(SACCT_DATA_USER_CPU == "UserCPU");
-                    assert!(SACCT_DATA_SYSTEM_CPU == "SystemCPU");
-                    push_duration(&mut sacct, field, &fieldvals[i]);
-                }
-                "ElapsedRaw" => {
-                    // NOTE - tags are the same as the fields
-                    assert!(SACCT_DATA_ELAPSED_RAW == "ElapsedRaw");
-                    push_uint(&mut sacct, field, &fieldvals[i]);
-                }
-                "AllocTRES" => {
-                    // NOTE - tags are the same as the fields
-                    assert!(SACCT_DATA_ALLOC_TRES == "AllocTRES");
-                    push_string(&mut sacct, field, &fieldvals[i]);
-                }
-
-                _ => {
-                    // A hack to make sure these names are used
-                    assert!(SLURM_JOB_GRESDETAIL != "zappa");
-                    assert!(SLURM_JOB_MIN_CPUSPER_NODE != "zappa");
-                    panic!("Bad field name");
-                }
-            }
-        }
-        if !sacct.is_empty() {
-            output_line.push_o(SLURM_JOB_SACCT, sacct);
-        }
-        jobs.push_o(output_line);
-    }
-    jobs
+    // If there are more fields than field names then that's because the job name
+    // contains `|`.  The JobName field always comes last.  Catenate excess fields until
+    // we have the same number of fields and names.  (Could just ignore excess fields
+    // instead.)
+    let n = SACCT_FIELDS.len();
+    let jobname = field_store[n - 1..].join("");
+    field_store[n - 1] = &jobname;
+    field_store[..n]
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<String>>()
 }
 
-fn push_uint(obj: &mut output::Object, name: &str, val: &str) {
-    push_uint_full(obj, name, val, 1, 0, false);
-}
-
-fn push_uint_full(
-    obj: &mut output::Object,
-    name: &str,
-    val: &str,
-    scale: u64,
-    bias: u64,
-    always: bool,
-) {
-    if val != "" {
-        if let Ok(n) = val.parse::<u64>() {
-            if n != 0 || bias != 0 || always {
-                obj.push_u(name, bias + n * scale);
-            }
+fn run_sacct(
+    system: &dyn systemapi::SystemAPI,
+    window: &Option<u32>,
+    span: &Option<String>,
+    uncompleted: bool,
+) -> Result<String, String> {
+    // Parse the options to compute the time range to pass to sacct.
+    let (from, to) = if let Some(s) = span {
+        let components = s.split(',').collect::<Vec<&str>>();
+        if components.len() != 2 || !check_ymd(components[0]) || !check_ymd(components[1]) {
+            return Err(format!("Bad --span: {}", s));
         }
-    }
-}
-
-fn push_duration(obj: &mut output::Object, name: &str, mut val: &str) {
-    // [DD-[hh:]]mm:ss
-    let days = if let Some((dd, rest)) = val.split_once('-') {
-        if let Ok(n) = dd.parse::<u64>() {
-            val = rest;
-            n
-        } else {
-            return;
-        }
+        (components[0].to_string(), components[1].to_string())
     } else {
-        0
-    };
-    let mut elts = val.split(':').collect::<Vec<&str>>();
-    let hours = if elts.len() == 3 {
-        if let Ok(n) = elts[0].parse::<u64>() {
-            elts.remove(0);
-            n
-        } else {
-            return;
+        let mut minutes = DEFAULT_WINDOW;
+        if let Some(w) = window {
+            minutes = *w;
         }
-    } else {
-        0
+        (format!("now-{minutes}minutes"), "now".to_string())
     };
-    let minutes = if let Ok(n) = elts[0].parse::<u64>() {
-        n
-    } else {
-        return;
-    };
-    let seconds = if let Ok(n) = elts[1].parse::<u64>() {
-        n
-    } else {
-        return;
-    };
-    let t = days * (24 * 60 * 60) + hours * (60 * 60) + minutes * 60 + seconds;
-    if t != 0 {
-        obj.push_u(name, t);
+    let mut states = SACCT_STATES.clone();
+    if uncompleted {
+        states.push("PENDING");
+        states.push("RUNNING");
     }
+    system.run_sacct(&states, &SACCT_FIELDS, &from, &to)
 }
 
-fn push_volume(obj: &mut output::Object, name: &str, val: &str) {
-    if val != "" {
-        let (val, scale) = if let Some(suffix) = val.strip_suffix('K') {
-            (suffix, 1024)
-        } else if let Some(suffix) = val.strip_suffix('M') {
-            (suffix, 1024 * 1024)
-        } else if let Some(suffix) = val.strip_suffix('G') {
-            (suffix, 1024 * 1024 * 1024)
-        } else {
-            (val, 1)
-        };
-        if let Ok(n) = val.parse::<u64>() {
-            if n != 0 {
-                obj.push_u(name, n * scale);
-            }
+fn check_ymd(s: &str) -> bool {
+    let mut k = 0;
+    for f in s.split('-') {
+        k += 1;
+        if f.parse::<u32>().is_err() {
+            return false;
         }
     }
-}
-
-fn push_string(obj: &mut output::Object, name: &str, val: &str) {
-    if val != "" && val != "Unknown" {
-        obj.push_s(name, val.to_string())
-    }
-}
-
-fn push_date(obj: &mut output::Object, name: &str, val: &str, local: &libc::tm) {
-    if val != "" && val != "Unknown" {
-        // Reformat timestamps.  The slurm date format is localtime without a time zone offset.
-        // This is bound to lead to problems eventually, so reformat.  If parsing fails, just
-        // transmit the date and let the consumer deal with it.
-        if let Ok(mut t) = time::parse_date_and_time_no_tzo(val) {
-            t.tm_gmtoff = local.tm_gmtoff;
-            t.tm_isdst = local.tm_isdst;
-            // If t.tm_zone is not null then it must point to static data, so
-            // copy it just to be safe.
-            t.tm_zone = local.tm_zone;
-            obj.push_s(name, time::format_iso8601(&t).to_string());
-        }
-    }
+    k == 3
 }
 
 // There is a test case that the "error" field is generated correctly in ../tests/slurm-no-sacct.sh.

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -9,6 +9,23 @@ use crate::systemapi;
 
 use std::io;
 
+#[cfg(feature = "daemon")]
+pub struct State<'a> {
+    system: &'a dyn systemapi::SystemAPI,
+    token: String,
+}
+
+#[cfg(feature = "daemon")]
+impl<'a> State<'a> {
+    pub fn new(system: &'a dyn systemapi::SystemAPI, token: String) -> State<'a> {
+        State { system, token }
+    }
+
+    pub fn run(&mut self, writer: &mut dyn io::Write) {
+        show_system(writer, self.system, self.token.clone(), false, true)
+    }
+}
+
 pub fn show_system(
     writer: &mut dyn io::Write,
     system: &dyn systemapi::SystemAPI,

--- a/src/testdata/daemon-stdio-config.txt
+++ b/src/testdata/daemon-stdio-config.txt
@@ -1,0 +1,18 @@
+# This is a valid test configuration.  Some of the spacing is wonky in order to test
+# space stripping.
+
+[global]
+cluster = mlx.hpc.uio.no
+role=node
+  
+[sample]
+cadence =5m
+  batchless = true
+load = false  
+
+[sysinfo]
+cadence = 24h
+
+[slurm]
+cadence = 1h
+window = 90m

--- a/src/time.rs
+++ b/src/time.rs
@@ -161,6 +161,67 @@ pub fn format_iso8601(timebuf: &libc::tm) -> String {
     }
 }
 
+// Taken from StackOverflow, converted to Rust, simplified.  The values returned are year, month,
+// day, hour, minute, second, where month, day, hour, minute, second are all zero-based (normally in
+// Unix timestamps, day and month are both 1-based).
+//
+// This iterates up from 1970 and is slowish.  For speed, we'd have a precomputed table of starting
+// values for select years.
+
+#[cfg(any(feature = "daemon", test))]
+pub fn unix_time_components(t: u64) -> (u64, u64, u64, u64, u64, u64) {
+    const SECONDS_PER_MINUTE: u64 = 60;
+    const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+    const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
+
+    let mut days = t / SECONDS_PER_DAY;
+    let mut year = 1970;
+    loop {
+        let n = if is_leap_year(year) { 366 } else { 365 };
+        if days < n {
+            break;
+        }
+        days -= n;
+        year += 1;
+    }
+
+    let days_per_month = [
+        31,
+        if is_leap_year(year) { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 0;
+    loop {
+        let n = days_per_month[month as usize];
+        if days < n {
+            break;
+        }
+        days -= n;
+        month += 1;
+    }
+
+    let seconds_remaining = t % SECONDS_PER_DAY;
+    let hour = seconds_remaining / SECONDS_PER_HOUR;
+    let minute = seconds_remaining / SECONDS_PER_MINUTE % SECONDS_PER_MINUTE;
+    let second = seconds_remaining % SECONDS_PER_MINUTE;
+
+    (year, month, days, hour, minute, second)
+}
+
+#[cfg(any(feature = "daemon", test))]
+fn is_leap_year(year: u64) -> bool {
+    year % 400 == 0 || (year % 4 == 0 && year % 100 != 0)
+}
+
 // This also tests now_local() and format_iso8601
 #[test]
 pub fn test_now_iso8601() {
@@ -200,4 +261,40 @@ pub fn test_parse_date_and_time_no_tzo() {
     assert!(parse_date_and_time_no_tzo("2022-07-01T23:5914").is_err());
     assert!(parse_date_and_time_no_tzo("2022-07-01T2359").is_err());
     assert!(parse_date_and_time_no_tzo("2022-07-01T23:59+03:30").is_err());
+}
+
+#[test]
+pub fn test_unix_time_components() {
+    // Test case from StackOverflow
+    // 08/18/2016 @ 2:41am (UTC)
+    let t = 1471488076;
+    let (year, month, day, hour, minute, second) = unix_time_components(t);
+    assert!(year == 2016);
+    assert!(month == 7);
+    assert!(day == 17);
+    assert!(hour == 2);
+    assert!(minute == 41);
+    assert!(second == 16);
+
+    // Sanity
+    let (year, month, day, hour, minute, second) = unix_time_components(0);
+    assert!(year == 1970);
+    assert!(month == 0);
+    assert!(day == 0);
+    assert!(hour == 0);
+    assert!(minute == 0);
+    assert!(second == 0);
+
+    // Generate test cases with `date -u +%s-%FT%T` - this yields both the
+    // second count and the date/time.
+
+    // 1740568588-2025-02-26T11:16:28
+    let t = 1740568588;
+    let (year, month, day, hour, minute, second) = unix_time_components(t);
+    assert!(year == 2025);
+    assert!(month == 1);
+    assert!(day == 25);
+    assert!(hour == 11);
+    assert!(minute == 16);
+    assert!(second == 28);
 }

--- a/tests/features.sh
+++ b/tests/features.sh
@@ -13,25 +13,27 @@ echo " Default"
 output=$(../target/debug/sonar sysinfo)
 jq . <<< $output > /dev/null
 
-echo " None"
-( cd .. ; cargo build --no-default-features )
-output=$(../target/debug/sonar sysinfo)
-jq . <<< $output > /dev/null
+for d in "" ",daemon"; do
+    echo " no-defaults$d"
+    ( cd .. ; cargo build --no-default-features --features "$d" )
+    output=$(../target/debug/sonar sysinfo)
+    jq . <<< $output > /dev/null
 
-echo " AMD"
-( cd .. ; cargo build --no-default-features --features amd )
-output=$(../target/debug/sonar sysinfo)
-jq . <<< $output > /dev/null
+    echo " amd$d"
+    ( cd .. ; cargo build --no-default-features --features amd$d )
+    output=$(../target/debug/sonar sysinfo)
+    jq . <<< $output > /dev/null
 
-echo " NVIDIA"
-( cd .. ; cargo build --no-default-features --features nvidia )
-output=$(../target/debug/sonar sysinfo)
-jq . <<< $output > /dev/null
+    echo " nvidia$d"
+    ( cd .. ; cargo build --no-default-features --features nvidia$d )
+    output=$(../target/debug/sonar sysinfo)
+    jq . <<< $output > /dev/null
 
-echo " NVIDIA,AMD"
-( cd .. ; cargo build --no-default-features --features nvidia,amd )
-output=$(../target/debug/sonar sysinfo)
-jq . <<< $output > /dev/null
+    echo " nvidia,amd$d"
+    ( cd .. ; cargo build --no-default-features --features nvidia,amd$d )
+    output=$(../target/debug/sonar sysinfo)
+    jq . <<< $output > /dev/null
+done
 
 # No XPU library yet so this feature should cause link failure
 

--- a/util/ingest-files/.gitignore
+++ b/util/ingest-files/.gitignore
@@ -1,0 +1,1 @@
+ingest-files


### PR DESCRIPTION
This is the base patch from #280, which is clean enough to land by itself.

This is a big patch, but there are two main changes here:

- the introduction of the "daemon" code and some supporting code, all of which is dormant unless actively used
- a rewrite of the sacct interface to break apart data extraction and formatting, this was overdue anyway and will be needed for subsequent work

This patch only has exfiltration to stdout / control messages from stdin, but has a simple API so that other exfiltration methods can be added, this has been vetted with a Kafka interface on the other queue.