### PR TITLE
Fix #274 - check Rust and Go code formatting

### DIFF
--- a/.github/workflows/test-go-format.yml
+++ b/.github/workflows/test-go-format.yml
@@ -1,0 +1,24 @@
+name: Test Go code formatting
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Display Go version
+      run: go version
+
+    - name: Format code
+      run: |
+        cd tests
+        ./go-format.sh

--- a/.github/workflows/test-rust-format.yml
+++ b/.github/workflows/test-rust-format.yml
@@ -1,0 +1,24 @@
+name: Test Rust code formatting
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Display Rust version
+      run: cargo --version
+
+    - name: Format code
+      run: |
+        cd tests
+        ./rust-format.sh

--- a/src/datasink.rs
+++ b/src/datasink.rs
@@ -62,10 +62,7 @@ fn control_message_reader(control_topic: String, sender: mpsc::Sender<daemon::Op
                                 value = value + " " + f;
                             }
                             if sender
-                                .send(daemon::Operation::Incoming(
-                                    key.to_string(),
-                                    value,
-                                ))
+                                .send(daemon::Operation::Incoming(key.to_string(), value))
                                 .is_err()
                             {
                                 return;

--- a/src/slurmjobs.rs
+++ b/src/slurmjobs.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::comparison_to_empty)]
-
 // Run sacct, extract output and reformat as CSV or JSON on stdout.
-
 #![allow(clippy::vec_box)]
 #![allow(clippy::len_zero)]
 #![allow(clippy::comparison_to_empty)]
@@ -503,7 +501,11 @@ fn render_jobs_newfmt(jobs: Vec<Box<JobAll>>) -> output::Array {
         push_string(&mut o, SLURM_JOB_GRESDETAIL, j.gres_detail);
         push_uint(&mut o, SLURM_JOB_REQ_CPUS, j.requested_cpus);
         push_uint(&mut o, SLURM_JOB_MIN_CPUSPER_NODE, j.minimum_cpus_per_node);
-        push_uint(&mut o, SLURM_JOB_REQ_MEMORY_PER_NODE, j.requested_memory_per_node);
+        push_uint(
+            &mut o,
+            SLURM_JOB_REQ_MEMORY_PER_NODE,
+            j.requested_memory_per_node,
+        );
         push_uint(&mut o, SLURM_JOB_REQ_NODES, j.requested_node_count);
         push_string(&mut o, SLURM_JOB_START, j.start_time);
         push_uint(&mut o, SLURM_JOB_SUSPENDED, j.suspend_time);

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -69,9 +69,18 @@ fn layout_sysinfo_newfmt(
     attrs.push_s(SYSINFO_ATTRIBUTES_OS_NAME, system.get_os_name());
     attrs.push_s(SYSINFO_ATTRIBUTES_OS_RELEASE, system.get_os_release());
     attrs.push_u(SYSINFO_ATTRIBUTES_SOCKETS, node_info.sockets);
-    attrs.push_u(SYSINFO_ATTRIBUTES_CORES_PER_SOCKET, node_info.cores_per_socket);
-    attrs.push_u(SYSINFO_ATTRIBUTES_THREADS_PER_CORE, node_info.threads_per_core);
-    attrs.push_s(SYSINFO_ATTRIBUTES_CPU_MODEL, node_info.cores[0].model_name.clone());
+    attrs.push_u(
+        SYSINFO_ATTRIBUTES_CORES_PER_SOCKET,
+        node_info.cores_per_socket,
+    );
+    attrs.push_u(
+        SYSINFO_ATTRIBUTES_THREADS_PER_CORE,
+        node_info.threads_per_core,
+    );
+    attrs.push_s(
+        SYSINFO_ATTRIBUTES_CPU_MODEL,
+        node_info.cores[0].model_name.clone(),
+    );
     attrs.push_s(SYSINFO_ATTRIBUTES_ARCHITECTURE, system.get_architecture());
     attrs.push_u(SYSINFO_ATTRIBUTES_MEMORY, node_info.mem_kb);
     let topo_svg = "".to_string(); // TODO: should be in node_info
@@ -135,15 +144,24 @@ fn layout_card_info_newfmt(node_info: &NodeInfo) -> output::Array {
         gpu.push_s(SYSINFO_GPU_CARD_ADDRESS, bus_addr.to_string());
         gpu.push_i(SYSINFO_GPU_CARD_INDEX, device.index as i64);
         gpu.push_s(SYSINFO_GPU_CARD_UUID, device.uuid.to_string());
-        gpu.push_s(SYSINFO_GPU_CARD_MANUFACTURER, node_info.card_manufacturer.clone());
+        gpu.push_s(
+            SYSINFO_GPU_CARD_MANUFACTURER,
+            node_info.card_manufacturer.clone(),
+        );
         gpu.push_s(SYSINFO_GPU_CARD_MODEL, model.to_string());
         gpu.push_s(SYSINFO_GPU_CARD_ARCHITECTURE, arch.to_string());
         gpu.push_s(SYSINFO_GPU_CARD_DRIVER, driver.to_string());
         gpu.push_s(SYSINFO_GPU_CARD_FIRMWARE, firmware.to_string());
         gpu.push_u(SYSINFO_GPU_CARD_MEMORY, *mem_size_kib);
         gpu.push_i(SYSINFO_GPU_CARD_POWER_LIMIT, *power_limit_watt as i64);
-        gpu.push_i(SYSINFO_GPU_CARD_MAX_POWER_LIMIT, *max_power_limit_watt as i64);
-        gpu.push_i(SYSINFO_GPU_CARD_MIN_POWER_LIMIT, *min_power_limit_watt as i64);
+        gpu.push_i(
+            SYSINFO_GPU_CARD_MAX_POWER_LIMIT,
+            *max_power_limit_watt as i64,
+        );
+        gpu.push_i(
+            SYSINFO_GPU_CARD_MIN_POWER_LIMIT,
+            *min_power_limit_watt as i64,
+        );
         gpu.push_i(SYSINFO_GPU_CARD_MAX_CECLOCK, *max_ce_clock_mhz as i64);
         gpu.push_i(SYSINFO_GPU_CARD_MAX_MEMORY_CLOCK, *max_mem_clock_mhz as i64);
         gpu_info.push_o(gpu);

--- a/tests/go-format.sh
+++ b/tests/go-format.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Note, this should not be run by `run_tests.sh` since it is normal for code to be unformatted
+# during development.
+
+output=$(gofmt -l ../util)
+if [[ $output != "" ]]; then
+    echo "FORMATTING FAILURE!"
+    echo "The following files are not properly formatted (go fmt):"
+    echo "$output"
+    exit 1
+fi

--- a/tests/rust-format.sh
+++ b/tests/rust-format.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Note, this should not be run by `run_tests.sh` since it is normal for code to be unformatted
+# during development.
+
+output=$(cargo fmt --check --message-format short)
+if [[ $output != "" ]]; then
+    echo "FORMATTING FAILURE!"
+    echo "The following files are not properly formatted (cargo fmt):"
+    echo "$output"
+    exit 1
+fi

--- a/util/formats/newfmt/types.go
+++ b/util/formats/newfmt/types.go
@@ -57,10 +57,10 @@ import (
 //
 // The working hypothesis is that:
 //
-// - all necessary Slurm data can be extracted from a single node in the cluster, as they only
-//   include data that Slurm collects and stores for itself
-// - the Slurm data collection can be performed by sampling, ie, by running data collection
-//   periodically using externally available Slurm tools, and not by getting callbacks from Slurm
+//   - all necessary Slurm data can be extracted from a single node in the cluster, as they only
+//     include data that Slurm collects and stores for itself
+//   - the Slurm data collection can be performed by sampling, ie, by running data collection
+//     periodically using externally available Slurm tools, and not by getting callbacks from Slurm
 //
 // That does not remove performance constraints, as the Slurm system is already busy and does not
 // need an extra load from a polling client that runs often.  It does ease performance constraints,


### PR DESCRIPTION
The checks for proper format are both fast (given how tiny the repo is) so I've broken them out as separate workflows.  Also included are some reformats, of course, since otherwise this PR would not pass the tests...  The new tests have to be run manually from the tests directory, they are not integrated into run_tests.sh, see the bug for discussion.