### PR TITLE
Fix #310 - platform output directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: all test
+.PHONY: debug release test
+ARCH=$(shell uname -m)
 
-all:
-	@echo "Select a specific target"
+debug:
+	CARGO_TARGET_DIR=target/$(ARCH) cargo build
+
+release:
+	CARGO_TARGET_DIR=target/$(ARCH) cargo build --release
 
 test:
 	cargo test


### PR DESCRIPTION
Do it all in the makefile.  Now, "make" to get a debug build and "make release" for a release build.  I could make it an explicit option for the debug build too.