### PR TITLE
Fix #293 - Relicense util/formats

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+The code below util/formats has its own license; see the LICENSE file
+in that directory.
+
+The parts of Sonar not covered by a separate license are covered by
+the following license.
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/util/formats/LICENSE
+++ b/util/formats/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Norwegian AI Cloud 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/util/formats/newfmt/decode_cluster.go
+++ b/util/formats/newfmt/decode_cluster.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/decode_jobs.go
+++ b/util/formats/newfmt/decode_jobs.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/decode_samples.go
+++ b/util/formats/newfmt/decode_samples.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/decode_sysinfo.go
+++ b/util/formats/newfmt/decode_sysinfo.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/to_oldfmt.go
+++ b/util/formats/newfmt/to_oldfmt.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // The use case for this is transitional - when we receive new sysinfo but want to store it in old
 // data files.  Note there is no old format for cluster data.
 //

--- a/util/formats/newfmt/types.go
+++ b/util/formats/newfmt/types.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // This is a machine-processable and partly executable specification for the new JSON format for
 // Sonar output.  It is processable into Rust code and Markdown docs by code in ../../process-doc.
 //

--- a/util/formats/newfmt_test.go
+++ b/util/formats/newfmt_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // The purpose of this test:
 //
 // - touch every defined data field at least once and make sure it has the expected value

--- a/util/formats/oldfmt/decode_samples.go
+++ b/util/formats/oldfmt/decode_samples.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Decode old sample (aka `sonar ps`) data.
 //
 // Old CSV data are delivered in batches where the first record can carry additional information

--- a/util/formats/oldfmt/decode_slurm.go
+++ b/util/formats/oldfmt/decode_slurm.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package oldfmt
 
 import (

--- a/util/formats/oldfmt/decode_sysinfo.go
+++ b/util/formats/oldfmt/decode_sysinfo.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package oldfmt
 
 import (

--- a/util/formats/oldfmt/types.go
+++ b/util/formats/oldfmt/types.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // JSON and CSV field names were always the same.  Any comments here are meant to be informative,
 // the authoritative documentation is still doc/OLD-FORMAT.md.
 //

--- a/util/formats/oldfmt_test.go
+++ b/util/formats/oldfmt_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Test the decoders for the old data format.  Currently we test only the dominant formats: JSON for
 // sysinfo, CSV for samples and slurmjobs.
 

--- a/util/formats/testing.go
+++ b/util/formats/testing.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package formats
 
 import (


### PR DESCRIPTION
Relicense code in util/formats (only) under the MIT license and claim the copyright of that code for NAIC.

I would not want this to be seen as some kind of fait accompli so by all means lets discuss, but I hope this is a sensible compromise.
