### PR TITLE
No bug: decouple tests from cargo target directory

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -6,3 +6,4 @@ daemon-interrupt-*.txt
 daemon-kafka-*.txt
 daemon-directory-*.txt
 daemon-directory-data
+interrupt.output.txt

--- a/tests/amd-gpu.sh
+++ b/tests/amd-gpu.sh
@@ -12,13 +12,11 @@ if [[ ! -e /sys/module/amdgpu ]]; then
     exit 0
 fi
 
-# amd is enabled by default
-( cd .. ; cargo build )
-
 # Test that sysinfo finds the cards.  This is also sufficient to test that the GPU SMI library has
 # been found and is loaded.
 
-output=$(../target/debug/sonar sysinfo)
+# amd is enabled by default
+output=$(cargo run -- sysinfo)
 numcards=$(jq .gpu_cards <<< $output)
 if [[ ! ( $numcards =~ ^[0-9]+$ ) ]]; then
     echo "Bad output from jq: <$numcards>"
@@ -35,7 +33,7 @@ fi
 #
 # TODO: This will be cleaner once we have json output.
 
-output=$(../target/debug/sonar ps --load --exclude-system-jobs)
+output=$(cargo run -- ps --load --exclude-system-jobs)
 infos=$(grep -E 'gpuinfo=.*fan%=.*tempc=.*' <<< $output)
 lines=$(wc -l <<< $infos)
 if (( $lines != 1 )); then

--- a/tests/cluster-no-sinfo.sh
+++ b/tests/cluster-no-sinfo.sh
@@ -4,7 +4,6 @@
 # Requirement: the `jq` utility.
 
 set -e
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -17,7 +16,7 @@ if [[ $(command -v sinfo) != "" ]]; then
     exit 0
 fi
 
-output=$(../target/debug/sonar cluster --cluster x --json)
+output=$(cargo run -- cluster --cluster x --json)
 error=$(jq .errors <<< $output)
 if [[ ! ( $error =~ "sinfo" ) ]]; then
     echo $output
@@ -27,7 +26,7 @@ fi
 
 # Default output is also "new json"
 
-output=$(../target/debug/sonar cluster --cluster x)
+output=$(cargo run -- cluster --cluster x)
 error=$(jq .errors <<< $output)
 if [[ ! ( $error =~ "sinfo" ) ]]; then
     echo $output

--- a/tests/cluster-syntax.sh
+++ b/tests/cluster-syntax.sh
@@ -4,7 +4,6 @@
 # Requirement: the `jq` utility.
 
 set -e
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -19,7 +18,7 @@ fi
 
 # JSON - the only format available
 
-output=$(../target/debug/sonar cluster --cluster x --json)
+output=$(cargo run -- --cluster x --json)
 
 # Syntax check
 

--- a/tests/command-line.sh
+++ b/tests/command-line.sh
@@ -3,38 +3,39 @@
 # Check that command line parsing is somewhat sane.
 
 set -e
-( cd ..; cargo build )
 
 # Allow both forms of argument syntax
-../target/debug/sonar ps --exclude-users=root,$LOGNAME > /dev/null
-../target/debug/sonar ps --exclude-users root,$LOGNAME > /dev/null
+cargo run -- ps --exclude-users=root,$LOGNAME > /dev/null
+cargo run -- ps --exclude-users root,$LOGNAME > /dev/null
 
 # Test all arguments in combination without --rollup
-../target/debug/sonar ps \
-                      --min-cpu-percent 0.5 \
-                      --min-mem-percent 1.8 \
-                      --min-cpu-time 10 \
-                      --exclude-system-jobs \
-                      --exclude-users root \
-                      --exclude-commands emacs \
-                      --lockdir . \
-                      > /dev/null
+cargo run -- \
+      ps \
+      --min-cpu-percent 0.5 \
+      --min-mem-percent 1.8 \
+      --min-cpu-time 10 \
+      --exclude-system-jobs \
+      --exclude-users root \
+      --exclude-commands emacs \
+      --lockdir . \
+      > /dev/null
 
 # Test all arguments in combination with --rollup
-../target/debug/sonar ps \
-                      --rollup \
-                      --min-cpu-percent 0.5 \
-                      --min-mem-percent 1.8 \
-                      --min-cpu-time 10 \
-                      --exclude-system-jobs \
-                      --exclude-users root \
-                      --exclude-commands emacs \
-                      --lockdir . \
-                      > /dev/null
+cargo run -- \
+      ps \
+      --rollup \
+      --min-cpu-percent 0.5 \
+      --min-mem-percent 1.8 \
+      --min-cpu-time 10 \
+      --exclude-system-jobs \
+      --exclude-users root \
+      --exclude-commands emacs \
+      --lockdir . \
+      > /dev/null
 
 # Signal error with code 2 for unknown arguments
 set +e
-output=$(../target/debug/sonar ps --zappa 2>&1)
+output=$(cargo run -- ps --zappa 2>&1)
 exitcode=$?
 set -e
 if [[ $exitcode != 2 ]]; then
@@ -44,7 +45,7 @@ fi
 
 # Signal error with code 2 for invalid arguments: missing string
 set +e
-output=$(../target/debug/sonar ps --lockdir 2>&1)
+output=$(cargo run -- ps --lockdir 2>&1)
 exitcode=$?
 set -e
 if [[ $exitcode != 2 ]]; then
@@ -54,7 +55,7 @@ fi
 
 # Signal error with code 2 for invalid arguments: bad number
 set +e
-output=$(../target/debug/sonar ps --min-cpu-time 7hello 2>&1)
+output=$(cargo run -- ps --min-cpu-time 7hello 2>&1)
 exitcode=$?
 set -e
 if [[ $exitcode != 2 ]]; then

--- a/tests/daemon-directory.sh
+++ b/tests/daemon-directory.sh
@@ -6,12 +6,11 @@
 
 set -e
 echo "This test takes about 20s"
-( cd .. ; cargo build )
 
 data_dir=daemon-directory-data
 logfile=daemon-directory-log.txt
 rm -rf $data_dir $logfile
-../target/debug/sonar daemon daemon-directory.ini 2>$logfile
+cargo run -- daemon daemon-directory.ini 2>$logfile
 
 if [[ ! -d $data_dir ]]; then
     echo "No data directory"

--- a/tests/daemon-kafka.sh
+++ b/tests/daemon-kafka.sh
@@ -5,7 +5,6 @@
 
 set -e
 echo "This test takes about 30s"
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -23,7 +22,7 @@ fi
 # and a message about this is printed on stdout (in addition to appearing in the log).
 
 if [[ $SKIP == "" ]]; then
-    SONARTEST_MOCK_KAFKA=fail-all-odd-messages ../target/debug/sonar daemon daemon-kafka.ini > $outfile 2> $logfile
+    SONARTEST_MOCK_KAFKA=fail-all-odd-messages cargo run -- daemon daemon-kafka.ini > $outfile 2> $logfile
 fi
 
 # The ini produces one record every second but has a 10s sending window and runs the daemon for 30s.

--- a/tests/daemon.sh
+++ b/tests/daemon.sh
@@ -5,7 +5,6 @@
 
 set -e
 echo " This takes about 15s"
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -19,7 +18,7 @@ fi
 rm -f daemon-output.txt
 before=$(date +%s)
 ( echo "exit exit exit" ; sleep 10 ; echo "zappa.hpc.axis-of-eval.org.control.node exit" ) | \
-    ../target/debug/sonar daemon daemon.ini > daemon-output.txt
+    cargo run -- daemon daemon.ini > daemon-output.txt
 after=$(date +%s)
 
 if (( $after - $before < 5 )); then

--- a/tests/exclude-commands.sh
+++ b/tests/exclude-commands.sh
@@ -3,8 +3,7 @@
 # Test that the --exclude-commands switch works.
 
 set -e
-( cd .. ; cargo build )
-numbad=$(../target/debug/sonar ps --exclude-commands bash,sh,zsh,csh,ksh,tcsh,kworker | \
+numbad=$(cargo run -- ps --exclude-commands bash,sh,zsh,csh,ksh,tcsh,kworker | \
     awk "
 /,cmd=kworker/ { print }
 /,cmd=(ba|z|c|k|tc|)sh/ { print }

--- a/tests/exclude-system-jobs.sh
+++ b/tests/exclude-system-jobs.sh
@@ -5,8 +5,7 @@
 # list to get the uid, then collect the uids that are < 1000 - these are wrong.
 
 set -e
-( cd .. ; cargo build )
-numbad=$(../target/debug/sonar ps --exclude-system-jobs | \
+numbad=$(cargo run -- ps --exclude-system-jobs | \
              awk '
 {
     s=substr($0, index($0, ",user=")+6)

--- a/tests/exclude-users.sh
+++ b/tests/exclude-users.sh
@@ -3,8 +3,7 @@
 # Test that the --exclude-users switch works.
 
 set -e
-( cd .. ; cargo build )
-numbad=$(../target/debug/sonar ps --exclude-users root,root,root,$LOGNAME | \
+numbad=$(cargo run -- ps --exclude-users root,root,root,$LOGNAME | \
     awk "
 /,user=root,/ { print }
 /,user=$LOGNAME,/ { print }

--- a/tests/gpuinfo.sh
+++ b/tests/gpuinfo.sh
@@ -9,18 +9,16 @@ if [[ ! -e /sys/module/nvidia ]]; then
     exit 0
 fi
 
-( cd .. ; cargo build )
-
 # The field is going to be there because cards always have some non-default data (fan speeds,
 # performance state, power, clocks).
 
-loadlines=$(../target/debug/sonar ps --load | grep -E ',"?gpuinfo=' | wc -l)
+loadlines=$(cargo run -- ps --load | grep -E ',"?gpuinfo=' | wc -l)
 if [[ $loadlines -ne 1 ]]; then
     echo "Did not emit gpuinfo data properly - not exactly 1: $loadlines"
     exit 1
 fi
 
-loadlines=$(../target/debug/sonar ps | grep -E ',"?gpuinfo=' | wc -l)
+loadlines=$(cargo run -- ps | grep -E ',"?gpuinfo=' | wc -l)
 if [[ $loadlines -ne 0 ]]; then
     echo "Did not emit gpuinfo data properly - not exactly 0: $loadlines"
     exit 1

--- a/tests/hostname.sh
+++ b/tests/hostname.sh
@@ -3,8 +3,7 @@
 # Check that sonar reports the correct hostname
 
 set -e
-( cd ..; cargo build )
-if [[ $(../target/debug/sonar ps | head -n 1 | grep ",host=$(hostname)," | wc -l) == 0 ]]; then
+if [[ $(cargo run -- ps | head -n 1 | grep ",host=$(hostname)," | wc -l) == 0 ]]; then
     echo "Wrong hostname??"
     exit 1
 fi

--- a/tests/kafka-interactive/01-manual-kafka/run-sonar.sh
+++ b/tests/kafka-interactive/01-manual-kafka/run-sonar.sh
@@ -5,4 +5,5 @@
 
 ( cd ../../.. ; cargo build )
 ( cd ../../../util/ssl ; make all )
-../../../target/debug/sonar daemon sonar-nonslurm-node-ssl-saslfile.ini
+( cd ../../.. ; cargo run -- daemon sonar-nonslurm-node-ssl-saslfile.ini )
+

--- a/tests/kafka-interactive/02-kafka-docker/run-sonar.sh
+++ b/tests/kafka-interactive/02-kafka-docker/run-sonar.sh
@@ -5,9 +5,9 @@
 
 SCRIPT_DIR=$(realpath -L $(dirname $0))
 
-( cd $SCRIPT_DIR/../.. ; cargo build )
+( cd $SCRIPT_DIR/../../.. ; cargo build )
 
 # This shoule not be necessary if you followed the instruction in README.md
 # ( cd ./ssl ; make all )
 
-$SCRIPT_DIR/../../../target/debug/sonar daemon sonar-nonslurm-node-ssl-sasl.ini
+( cd $SCRIPT_DIR/../../.. ; cargo run -- daemon sonar-nonslurm-node-ssl-sasl.ini

--- a/tests/load.sh
+++ b/tests/load.sh
@@ -4,14 +4,13 @@
 
 set -e
 
-( cd .. ; cargo build )
-loadlines=$(../target/debug/sonar ps --load | grep ',load=' | wc -l)
+loadlines=$(cargo run -- ps --load | grep ',load=' | wc -l)
 if [[ $loadlines -ne 1 ]]; then
     echo "Did not emit load data properly - not exactly 1"
     exit 1
 fi
 
-loadlines=$(../target/debug/sonar ps | grep ',load=' | wc -l)
+loadlines=$(cargo run -- ps | grep ',load=' | wc -l)
 if [[ $loadlines -ne 0 ]]; then
     echo "Did not emit load data properly - not exactly 0"
     exit 1

--- a/tests/lockfile.sh
+++ b/tests/lockfile.sh
@@ -7,14 +7,13 @@ set -e
 logfile=lockfile.output.txt
 
 echo " This takes about 15s"
-( cd .. ; cargo build )
 rm -f $logfile sonar-lock.*
-SONARTEST_WAIT_LOCKFILE=1 ../target/debug/sonar ps --lockdir . > /dev/null &
+SONARTEST_WAIT_LOCKFILE=1 cargo run -- ps --lockdir . > /dev/null &
 bgpid=$!
 # Wait for the first process to get going
 sleep 3
-../target/debug/sonar ps --lockdir . 2> $logfile
-if [[ $(cat $logfile) != 'Info: Lockfile present, exiting' ]]; then
+cargo run -- ps --lockdir . 2> $logfile
+if [[ $(tail -n 1 $logfile) != 'Info: Lockfile present, exiting' ]]; then
     echo "Unexpected output!"
     exit 1
 fi

--- a/tests/min-cpu-time.sh
+++ b/tests/min-cpu-time.sh
@@ -3,8 +3,7 @@
 # Test that the --min-cpu-time switch works.
 
 set -e
-( cd .. ; cargo build )
-numbad=$(../target/debug/sonar ps --min-cpu-time 5 | \
+numbad=$(cargo run -- ps --min-cpu-time 5 | \
              awk '
 {
     s=substr($0, index($0, ",cputime_sec=")+13)

--- a/tests/no-gpu.sh
+++ b/tests/no-gpu.sh
@@ -9,14 +9,12 @@
 # Add other GPU types here when we add support for them, the tests below should start failing when
 # that happens.
 set -e
-if [[ -e /sys/module/amdgpu || -e /sys/module/nvidia || -e /sys/module/i915 ]]; then
+if [[ -e /sys/module/amdgpu || -e /sys/module/nvidia || -e /sys/module/i915 || -e /sys/module/habanalabs ]]; then
     echo " GPUs detected"
     exit 0
 fi
 
-( cd .. ; cargo build )
-
-output=$(../target/debug/sonar sysinfo)
+output=$(cargo run -- sysinfo)
 numcards=$(jq .gpu_cards <<< $output)
 if (( $numcards != 0 )); then
     echo "Bad output from jq: <$numcards> should be zero"
@@ -26,7 +24,7 @@ fi
 # TODO: Once we have JSON output, use that here!  The CSV matching is very crude and there's a small
 # chance that it will have a false positive on sufficiently perverse command names.
 
-output=$(../target/debug/sonar ps --load)
+output=$(cargo run -- ps --load)
 if [[ $output =~ ,gpu[%a-z_-]+= ]]; then
     echo "Bad output: unexpected GPU fields in output on non-gpu system"
     exit 1

--- a/tests/nvidia-gpu.sh
+++ b/tests/nvidia-gpu.sh
@@ -12,13 +12,11 @@ if [[ ! -e /sys/module/nvidia ]]; then
     exit 0
 fi
 
-# nvidia is enabled by default
-( cd .. ; cargo build )
-
 # Test that sysinfo finds the cards.  This is also sufficient to test that the GPU SMI library has
 # been found and is loaded.
 
-output=$(../target/debug/sonar sysinfo)
+# nvidia is enabled by default
+output=$(cargo run -- sysinfo)
 numcards=$(jq .gpu_cards <<< $output)
 if [[ ! ( $numcards =~ ^[0-9]+$ ) ]]; then
     echo "Bad output from jq: <$numcards>"
@@ -35,7 +33,7 @@ fi
 #
 # TODO: This will be cleaner once we have json output.
 
-output=$(../target/debug/sonar ps --load --exclude-system-jobs)
+output=$(cargo run -- ps --load --exclude-system-jobs)
 infos=$(grep -E 'gpuinfo=.*fan%=.*tempc=.*' <<< $output)
 lines=$(wc -l <<< $infos)
 if (( $lines != 1 )); then

--- a/tests/ps-interrupt.sh
+++ b/tests/ps-interrupt.sh
@@ -4,15 +4,14 @@
 # in an orderly way with a message on stderr.
 
 set -e
-echo " This takes about 15s"
-( cd .. ; cargo build )
+echo " This takes about 20s"
 rm -f interrupt.output.txt
-SONARTEST_WAIT_INTERRUPT=1 ../target/debug/sonar ps 2> interrupt.output.txt &
+SONARTEST_WAIT_INTERRUPT=1 cargo run -- ps 2> interrupt.output.txt &
 bgpid=$!
-sleep 3
+sleep 10
 kill -TERM $bgpid
 sleep 10
-if [[ $(cat interrupt.output.txt) != 'Info: Interrupt flag was set!' ]]; then
+if [[ $(tail -n 1 interrupt.output.txt) != 'Info: Interrupt flag was set!' ]]; then
     echo "Unexpected output!"
     exit 1
 fi

--- a/tests/ps-syntax.sh
+++ b/tests/ps-syntax.sh
@@ -4,7 +4,6 @@
 # Requirement: the `jq` utility.
 
 set -e
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -22,7 +21,7 @@ fi
 # We don't have the infra at the moment to check the CSV output, plus CSV is so flexible that it's
 # sort of hard to check it.
 
-output=$(../target/debug/sonar ps)
+output=$(cargo run -- ps)
 count=$(wc -l <<< $output)
 if [[ $count -le 0 ]]; then
     echo "Must have some number of output lines"
@@ -55,7 +54,7 @@ echo "CSV ok"
 
 # Check that it is syntactically sane
 
-output=$(../target/debug/sonar ps --load --exclude-system-jobs --cluster x --json)
+output=$(cargo run -- ps --load --exclude-system-jobs --cluster x --json)
 jq . <<< $output > /dev/null
 
 # Check that the envelope has required fields

--- a/tests/rollup.sh
+++ b/tests/rollup.sh
@@ -11,13 +11,12 @@
 
 set -e
 
-( cd .. ; cargo build )
 make --quiet
 
 echo " This takes about 10s"
 ./rollup 3 &
 sleep 3
-output=$(SONARTEST_ROLLUP=1 ../target/debug/sonar ps --rollup --exclude-system-jobs)
+output=$(SONARTEST_ROLLUP=1 cargo run -- ps --rollup --exclude-system-jobs)
 matches=$(grep ,cmd=rollup, <<< $output)
 rolled=$(grep ,rolledup=1 <<< $matches)
 rolled2=$(grep ,rolledup= <<< $matches)

--- a/tests/rollup2.sh
+++ b/tests/rollup2.sh
@@ -10,13 +10,12 @@
 
 set -e
 
-( cd .. ; cargo build )
 make --quiet
 
 echo " This takes about 10s"
 ./rollup2 3 &
 sleep 3
-output=$(SONARTEST_ROLLUP=1 ../target/debug/sonar ps --rollup --exclude-system-jobs)
+output=$(SONARTEST_ROLLUP=1 cargo run -- ps --rollup --exclude-system-jobs)
 # Grep will exit with code 1 if no lines are matched
 matches1=$(grep -E ',cmd=rollupchild,.*,rolledup=4' <<< $output)
 matches2=$(grep -E ',cmd=rollupchild2,.*,rolledup=3' <<< $output)

--- a/tests/slurm-no-sacct.sh
+++ b/tests/slurm-no-sacct.sh
@@ -4,7 +4,6 @@
 # Requirement: the `jq` utility.
 
 set -e
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -17,7 +16,7 @@ if [[ $(command -v sacct) != "" ]]; then
     exit 0
 fi
 
-output=$(../target/debug/sonar slurm --cluster x --json)
+output=$(cargo run -- slurm --cluster x --json)
 error=$(jq .errors <<< $output)
 if [[ ! ( $error =~ "sacct" ) ]]; then
     echo $output
@@ -25,7 +24,7 @@ if [[ ! ( $error =~ "sacct" ) ]]; then
     exit 1
 fi
 
-output=$(../target/debug/sonar slurm --csv)
+output=$(cargo run -- slurm --csv)
 if [[ ! ( $output =~ "error=sacct" ) ]]; then
     echo "Expected specific error string, got '$output'"
     exit 1

--- a/tests/slurm-syntax.sh
+++ b/tests/slurm-syntax.sh
@@ -4,7 +4,6 @@
 # Requirement: the `jq` utility.
 
 set -e
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -21,7 +20,7 @@ fi
 #
 # There's no guarantee that there is a record.
 
-output=$(../target/debug/sonar slurm)
+output=$(cargo run -- slurm)
 if [[ $output == "" ]]; then
     echo "No output"
     exit 0
@@ -38,7 +37,7 @@ echo "CSV ok"
 
 # JSON
 
-output=$(../target/debug/sonar slurm --cluster x --json)
+output=$(cargo run -- slurm --cluster x --json)
 
 # Syntax check
 

--- a/tests/sysinfo-syntax.sh
+++ b/tests/sysinfo-syntax.sh
@@ -4,7 +4,6 @@
 # Requirement: the `jq` utility.
 
 set -e
-( cd .. ; cargo build )
 if [[ $(command -v jq) == "" ]]; then
     echo "Install jq first"
     exit 1
@@ -12,14 +11,14 @@ fi
 
 # JSON syntax check
 
-output=$(../target/debug/sonar sysinfo)
+output=$(cargo run -- sysinfo)
 jq . <<< $output > /dev/null
 
 echo " JSON ok"
 
 # Superficial CSV check, check that the version number is there
 
-output=$(../target/debug/sonar sysinfo --csv)
+output=$(cargo run -- sysinfo --csv)
 if [[ ! ( $output =~ version= ) ]]; then
     echo "CSV missing version number"
     exit 1

--- a/tests/user.sh
+++ b/tests/user.sh
@@ -3,8 +3,7 @@
 # Check that sonar can look up users.  There will be at least one process for the user: sonar.
 
 set -e
-( cd ..; cargo build )
-if [[ $(../target/debug/sonar ps | grep ",user=$USER," | wc -l) == 0 ]]; then
+if [[ $(cargo run -- ps | grep ",user=$USER," | wc -l) == 0 ]]; then
     echo "User name lookup fails??"
     exit 1
 fi


### PR DESCRIPTION
On eX3 I have set my cargo target directory to somewhere on /global/D1 since /home keeps filling up.  This means that test cases that would run ( cd ..; cargo build; target/debug/sonar ...) would either fail or quietly pick up a stale binary.  Instead, we should simply do ( cargo run -- ... ) which will build (in the root dir, with the proper output directory) and run the executable.

In a couple cases this means that the test will be slower, which means some timeouts had to be adjusted, but by and large this is clean.

One test was updated to cleanly combine features for feature testing.