### PR TITLE
Fix #360 - Better xpu detection

### DIFF
--- a/src/gpu/xpu.rs
+++ b/src/gpu/xpu.rs
@@ -1,8 +1,6 @@
 use crate::gpu::{self, xpu_smi};
 use crate::ps;
 
-use std::path::Path;
-
 pub struct XpuGPU {}
 
 pub fn probe() -> Option<Box<dyn gpu::Gpu>> {
@@ -46,10 +44,6 @@ impl gpu::Gpu for XpuGPU {
     }
 }
 
-// Probably this, though actually hard to figure out exactly.  Looking at strings in the smi
-// library, i915 is definitely being looked for, and some other output also indicates this is what
-// we want.
-
 fn xpu_present() -> bool {
-    Path::new("/sys/module/i915").exists()
+    xpu_smi::xpu_detect()
 }

--- a/src/gpu/xpu_smi.rs
+++ b/src/gpu/xpu_smi.rs
@@ -5,6 +5,8 @@ use crate::ps;
 use crate::types::{Pid, Uid};
 use crate::util::cstrdup;
 
+use std::path::Path;
+
 ////// C library API //////////////////////////////////////////////////////////////////////////////
 
 // The data structures and signatures defined here must be exactly those defined in the header file,
@@ -86,6 +88,15 @@ extern "C" {
 }
 
 ////// End C library API //////////////////////////////////////////////////////////////////////////
+
+pub fn xpu_detect() -> bool {
+    if Path::new("/sys/module/i915").exists() {
+        let mut num_devices: cty::uint32_t = 0;
+        unsafe { xpu_device_get_count(&mut num_devices) != -1 }
+    } else {
+        false
+    }
+}
 
 pub fn get_card_configuration() -> Option<Vec<gpu::Card>> {
     let mut num_devices: cty::uint32_t = 0;


### PR DESCRIPTION
A simple fix: if the file is present, try to load the smi library and initialize it; if that works, it's an XPU.