### PR TITLE
Fix #433 - Implement configurable batching of slurm jobs data

### DIFF
--- a/doc/HOWTO-DAEMON.md
+++ b/doc/HOWTO-DAEMON.md
@@ -151,6 +151,7 @@ hundred KB when base64-encoded, while the output for `hwloc-ls` is usually quite
 cadence = <duration value>
 window = <duration value>                       # default 2*cadence
 uncompleted = <bool>                            # default false
+batch-size = <count>                            # default none
 ```
 
 The `window` is the sacct time window used for looking for data.
@@ -159,6 +160,11 @@ The `uncompleted` option, if true, triggers the inclusion of data about pending 
 This will result in multiple transmissions of data for the same `(job_id,job_step)`, one at each
 sample point.  If a job stays in, say, the PENDING state for several sampling windows then multiple
 transmissions for the job in the PENDING state will be seen.
+
+If `batch-size` is set it provides the maximum number of job records per output message.  This is
+basically a hack, but if `uncompleted` is true the message volume can be very large, and messages
+may become so large that they cause transmission issues, notably by default Kafka limits messages to
+1MB in size.  Setting `batch-size` can alleviate some of these problems.
 
 ### `[cluster]` section
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -91,6 +91,7 @@ pub struct JobsIni {
     pub cadence: Option<Dur>,
     pub window: Option<Dur>,
     pub uncompleted: bool,
+    pub batch_size: Option<usize>,
 }
 
 pub struct ClusterIni {
@@ -311,6 +312,7 @@ pub fn daemon_mode(
     let mut slurm_extractor = slurmjobs::State::new(
         ini.jobs.window.map(|c| c.to_minutes() as u32),
         ini.jobs.uncompleted,
+        ini.jobs.batch_size,
         &system,
         api_token.clone(),
     );
@@ -665,6 +667,7 @@ fn parse_config(config_file: &str) -> Result<Ini, String> {
             cadence: None,
             window: None,
             uncompleted: false,
+            batch_size: None,
         },
         cluster: ClusterIni { cadence: None },
     };
@@ -869,6 +872,13 @@ fn parse_config(config_file: &str) -> Result<Ini, String> {
                 "uncompleted" | "incomplete" => {
                     ini.jobs.uncompleted = parse_bool(&value)?;
                 }
+                "batch-size" => {
+                    ini.jobs.batch_size = Some(
+                        value
+                            .parse::<usize>()
+                            .map_err(|_| format!("Bad jobs.batch-size"))?,
+                    );
+                }
                 _ => return Err(format!("Invalid [jobs] setting name `{name}`")),
             },
             Section::Cluster => match name.as_str() {
@@ -1070,16 +1080,64 @@ pub fn test_parser() {
     assert!(parse_duration("", "3H12M35X", true).is_err());
 
     let ini = parse_config("src/testdata/daemon-stdio-config.txt").unwrap();
+
     assert!(ini.global.cluster == "mlx.hpc.uio.no");
     assert!(ini.global.role == "node");
     assert!(ini.global.lockdir == Some("/root".to_string()));
+    assert!(ini.global.topic_prefix == Some("zappa".to_string()));
+
+    assert!(ini.kafka.broker_address == "localhost:0000".to_string());
+    assert!(ini.kafka.sending_window == Dur::Hours(1));
+    assert!(ini.kafka.timeout == Dur::Minutes(1));
+    assert!(ini.kafka.ca_file == Some("test-ca".to_string()));
+    assert!(ini.kafka.sasl_password_file == Some("test-pass".to_string()));
+
+    assert!(ini.debug.time_limit == Some(Dur::Minutes(10)));
+    assert!(ini.debug.output_delay == Some(Dur::Minutes(1)));
+    assert!(ini.debug.verbose == true);
+
     assert!(ini.sample.cadence == Some(Dur::Minutes(5)));
     assert!(ini.sample.batchless);
     assert!(!ini.sample.load);
     assert!(ini.sample.rollup);
     assert!(ini.sample.min_cpu_time == Some(Dur::Minutes(1)));
+    assert!(!ini.sample.exclude_system_jobs);
+    let xusers = vec!["bob", "alice"];
+    assert!(ini.sample.exclude_users.len() == xusers.len());
+    for i in 0..xusers.len() {
+        assert!(&ini.sample.exclude_users[i] == xusers[i]);
+    }
+    let xcmds = vec!["ls", "runuser"];
+    assert!(ini.sample.exclude_commands.len() == xcmds.len());
+    for i in 0..xcmds.len() {
+        assert!(&ini.sample.exclude_commands[i] == xcmds[i]);
+    }
+
     assert!(ini.sysinfo.cadence == Some(Dur::Hours(24)));
+    assert!(!ini.sysinfo.on_startup);
+    assert!(ini.sysinfo.topo_svg_cmd == Some("hello".to_string()));
+    assert!(ini.sysinfo.topo_text_cmd == Some("goodbye".to_string()));
+
     assert!(ini.jobs.cadence == Some(Dur::Hours(1)));
     assert!(ini.jobs.window == Some(Dur::Minutes(90)));
-    // TODO: Test cluster
+    assert!(ini.jobs.batch_size == Some(17));
+    assert!(ini.jobs.uncompleted);
+
+    assert!(ini.cluster.cadence == Some(Dur::Minutes(15)));
+
+    let ini = parse_config("src/testdata/daemon-stdio-config2.txt").unwrap();
+
+    assert!(ini.global.cluster == "mlx.hpc.uio.no");
+    assert!(ini.global.role == "master");
+
+    assert!(ini.kafka.broker_address == "localhost:0000".to_string());
+    assert!(ini.kafka.ca_file == Some("myfile".to_string()));
+    assert!(ini.kafka.sasl_password == Some("qumquat".to_string()));
+
+    let ini = parse_config("src/testdata/daemon-stdio-config3.txt").unwrap();
+
+    assert!(ini.global.cluster == "fox.educloud.no");
+    assert!(ini.global.role == "master");
+
+    assert!(ini.directory.data_dir == Some("/dev/null/your/data/here".to_string()));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,9 @@ enum Commands {
         /// Include PENDING and RUNNING jobs
         deluge: bool,
 
+        /// If set, split output in multiple messages if the number of job records exceed this
+        batch_size: Option<usize>,
+
         /// Cluster name
         cluster: Option<String>,
     },
@@ -240,6 +243,7 @@ fn main() {
             span,
             csv,
             deluge,
+            batch_size,
             cluster,
         } => {
             let system = if cluster.is_some() {
@@ -252,6 +256,7 @@ fn main() {
                 window,
                 span,
                 *deluge,
+                *batch_size,
                 &system.freeze().expect("System initialization"),
                 token,
                 if *csv {
@@ -444,6 +449,7 @@ fn command_line() -> Commands {
                 let mut json = false;
                 let mut csv = false;
                 let mut deluge = false;
+                let mut batch_size = None;
                 let mut cluster = None;
                 while next < args.len() {
                     let arg = args[next].as_ref();
@@ -462,6 +468,10 @@ fn command_line() -> Commands {
                         (next, csv) = (new_next, true);
                     } else if let Some(new_next) = bool_arg(arg, &args, next, "--deluge") {
                         (next, deluge) = (new_next, true);
+                    } else if let Some((new_next, value)) =
+                        numeric_arg::<usize>(arg, &args, next, "--batch-size")
+                    {
+                        (next, batch_size) = (new_next, Some(value));
                     } else if let Some((new_next, value)) =
                         string_arg(arg, &args, next, "--cluster")
                     {
@@ -483,6 +493,7 @@ fn command_line() -> Commands {
                     csv,
                     cluster,
                     deluge,
+                    batch_size,
                 }
             }
             "cluster" => {
@@ -642,6 +653,8 @@ Options for `slurm`:
       database with older data.  Precludes --window
   --deluge
       Include PENDING and RUNNING jobs in the output, not just completed jobs.
+  --batch-size
+      Split into multiple JSON messages after this many job records.
   --csv
       Format output as CSV, not new JSON
   --oldfmt

--- a/src/slurmjobs.rs
+++ b/src/slurmjobs.rs
@@ -83,6 +83,7 @@ pub struct State<'a> {
     window: Option<u32>,
     token: String,
     uncompleted: bool,
+    batch_size: Option<usize>,
     system: &'a dyn systemapi::SystemAPI,
 }
 
@@ -132,6 +133,7 @@ impl<'a> State<'a> {
     pub fn new(
         window: Option<u32>, // Minutes
         uncompleted: bool,
+        batch_size: Option<usize>,
         system: &'a dyn systemapi::SystemAPI,
         token: String,
     ) -> State<'a> {
@@ -139,31 +141,21 @@ impl<'a> State<'a> {
             window,
             token,
             uncompleted,
+            batch_size,
             system,
         }
     }
 
     pub fn run(&mut self, writer: &mut dyn io::Write) {
-        match collect_sacct_jobs_newfmt(self.system, &self.window, &None, self.uncompleted) {
-            Ok(jobs) => {
-                // This will push out a record even if the jobs array is empty.  This is probably
-                // the right thing, it serves as a heartbeat.
-                let mut envelope = output::newfmt_envelope(self.system, self.token.clone(), &[]);
-                let (mut data, mut attrs) = output::newfmt_data(self.system, DATA_TAG_JOBS);
-                attrs.push_a(JOBS_ATTRIBUTES_SLURM_JOBS, render_jobs_newfmt(jobs));
-                data.push_o(JOBS_DATA_ATTRIBUTES, attrs);
-                envelope.push_o(JOBS_ENVELOPE_DATA, data);
-                output::write_json(writer, &output::Value::O(envelope));
-            }
-            Err(error) => {
-                let mut envelope = output::newfmt_envelope(self.system, self.token.clone(), &[]);
-                envelope.push_a(
-                    JOBS_ENVELOPE_ERRORS,
-                    output::newfmt_one_error(self.system, error),
-                );
-                output::write_json(writer, &output::Value::O(envelope));
-            }
-        }
+        show_slurm_jobs_newfmt(
+            writer,
+            &self.window,
+            &None,
+            self.uncompleted,
+            self.batch_size,
+            self.system,
+            self.token.clone(),
+        );
     }
 }
 
@@ -184,13 +176,14 @@ pub fn show_slurm_jobs(
     window: &Option<u32>,
     span: &Option<String>,
     uncompleted: bool,
+    batch_size: Option<usize>,
     system: &dyn systemapi::SystemAPI,
     token: String,
     fmt: Format,
 ) {
     match fmt {
         Format::NewJSON => {
-            show_slurm_jobs_newfmt(writer, window, span, uncompleted, system, token);
+            show_slurm_jobs_newfmt(writer, window, span, uncompleted, batch_size, system, token);
         }
         Format::CSV => {
             show_slurm_jobs_oldfmt(writer, window, span, system);
@@ -203,17 +196,32 @@ pub fn show_slurm_jobs_newfmt(
     window: &Option<u32>,
     span: &Option<String>,
     uncompleted: bool,
+    batch_size: Option<usize>,
     system: &dyn systemapi::SystemAPI,
     token: String,
 ) {
     match collect_sacct_jobs_newfmt(system, window, span, uncompleted) {
         Ok(jobs) => {
-            let mut envelope = output::newfmt_envelope(system, token, &[]);
-            let (mut data, mut attrs) = output::newfmt_data(system, DATA_TAG_JOBS);
-            attrs.push_a(JOBS_ATTRIBUTES_SLURM_JOBS, render_jobs_newfmt(jobs));
-            data.push_o(JOBS_DATA_ATTRIBUTES, attrs);
-            envelope.push_o(JOBS_ENVELOPE_DATA, data);
-            output::write_json(writer, &output::Value::O(envelope));
+            // This will push out a record even if the jobs array is empty.  It serves as a
+            // heartbeat.
+            let mut start = 0;
+            loop {
+                let xs = if let Some(n) = batch_size {
+                    &jobs[start..std::cmp::min(start + n, jobs.len())]
+                } else {
+                    &jobs
+                };
+                start += xs.len();
+                let mut envelope = output::newfmt_envelope(system, token.clone(), &[]);
+                let (mut data, mut attrs) = output::newfmt_data(system, DATA_TAG_JOBS);
+                attrs.push_a(JOBS_ATTRIBUTES_SLURM_JOBS, render_jobs_newfmt(xs));
+                data.push_o(JOBS_DATA_ATTRIBUTES, attrs);
+                envelope.push_o(JOBS_ENVELOPE_DATA, data);
+                output::write_json(writer, &output::Value::O(envelope));
+                if start == jobs.len() {
+                    break;
+                }
+            }
         }
         Err(error) => {
             let mut envelope = output::newfmt_envelope(system, token, &[]);
@@ -521,34 +529,34 @@ fn parse_volume_kb(val: &str) -> u64 {
     }
 }
 
-fn render_jobs_newfmt(jobs: Vec<Box<JobAll>>) -> output::Array {
+fn render_jobs_newfmt(jobs: &[Box<JobAll>]) -> output::Array {
     let mut a = output::Array::new();
     for j in jobs {
         let mut o = output::Object::new();
         push_uint(&mut o, SLURM_JOB_JOB_ID, j.job_id);
-        push_string(&mut o, SLURM_JOB_JOB_STEP, j.job_step);
-        push_string_full(&mut o, SLURM_JOB_JOB_NAME, j.job_name, false);
-        push_string(&mut o, SLURM_JOB_JOB_STATE, j.job_state);
+        push_string(&mut o, SLURM_JOB_JOB_STEP, j.job_step.clone());
+        push_string_full(&mut o, SLURM_JOB_JOB_NAME, j.job_name.clone(), false);
+        push_string(&mut o, SLURM_JOB_JOB_STATE, j.job_state.clone());
         push_uint(&mut o, SLURM_JOB_ARRAY_JOB_ID, j.array_job_id);
         push_uint(&mut o, SLURM_JOB_ARRAY_TASK_ID, j.array_task_id);
         push_uint(&mut o, SLURM_JOB_HET_JOB_ID, j.het_job_id);
         push_uint(&mut o, SLURM_JOB_HET_JOB_OFFSET, j.het_job_offset);
-        push_string_full(&mut o, SLURM_JOB_USER_NAME, j.user_name, false);
-        push_string_full(&mut o, SLURM_JOB_ACCOUNT, j.account, false);
-        push_string(&mut o, SLURM_JOB_SUBMIT_TIME, j.submit_time);
+        push_string_full(&mut o, SLURM_JOB_USER_NAME, j.user_name.clone(), false);
+        push_string_full(&mut o, SLURM_JOB_ACCOUNT, j.account.clone(), false);
+        push_string(&mut o, SLURM_JOB_SUBMIT_TIME, j.submit_time.clone());
         push_uint(&mut o, SLURM_JOB_TIMELIMIT, j.time_limit);
-        push_string(&mut o, SLURM_JOB_PARTITION, j.partition);
-        push_string_full(&mut o, SLURM_JOB_RESERVATION, j.reservation, false);
+        push_string(&mut o, SLURM_JOB_PARTITION, j.partition.clone());
+        push_string_full(&mut o, SLURM_JOB_RESERVATION, j.reservation.clone(), false);
         if j.nodes.len() > 0 {
             let mut ns = output::Array::new();
-            for n in j.nodes {
-                ns.push_s(n);
+            for n in &j.nodes {
+                ns.push_s(n.clone());
             }
             o.push_a(SLURM_JOB_NODE_LIST, ns);
         }
         push_uint(&mut o, SLURM_JOB_PRIORITY, j.priority);
-        push_string(&mut o, SLURM_JOB_LAYOUT, j.distribution);
-        push_string(&mut o, SLURM_JOB_GRESDETAIL, j.gres_detail);
+        push_string(&mut o, SLURM_JOB_LAYOUT, j.distribution.clone());
+        push_string(&mut o, SLURM_JOB_GRESDETAIL, j.gres_detail.clone());
         push_uint(&mut o, SLURM_JOB_REQ_CPUS, j.requested_cpus);
         push_uint(
             &mut o,
@@ -556,13 +564,13 @@ fn render_jobs_newfmt(jobs: Vec<Box<JobAll>>) -> output::Array {
             j.requested_memory_per_node,
         );
         push_uint(&mut o, SLURM_JOB_REQ_NODES, j.requested_node_count);
-        push_string(&mut o, SLURM_JOB_START, j.start_time);
+        push_string(&mut o, SLURM_JOB_START, j.start_time.clone());
         push_uint(&mut o, SLURM_JOB_SUSPENDED, j.suspend_time);
-        push_string(&mut o, SLURM_JOB_END, j.end_time);
+        push_string(&mut o, SLURM_JOB_END, j.end_time.clone());
         push_uint(&mut o, SLURM_JOB_EXIT_CODE, j.exit_code);
         let mut s = output::Object::new();
         push_uint(&mut s, SACCT_DATA_MIN_CPU, j.sacct_min_cpu);
-        push_string(&mut s, SACCT_DATA_ALLOC_TRES, j.sacct_alloc_tres);
+        push_string(&mut s, SACCT_DATA_ALLOC_TRES, j.sacct_alloc_tres.clone());
         push_uint(&mut s, SACCT_DATA_AVE_CPU, j.sacct_ave_cpu);
         push_uint(&mut s, SACCT_DATA_AVE_DISK_READ, j.sacct_ave_disk_read);
         push_uint(&mut s, SACCT_DATA_AVE_DISK_WRITE, j.sacct_ave_disk_write);

--- a/src/testdata/daemon-stdio-config.txt
+++ b/src/testdata/daemon-stdio-config.txt
@@ -1,21 +1,50 @@
-# This is a valid test configuration.  Some of the spacing is wonky in order to test
-# space stripping.
+# This is a valid test configuration.  Some of the spacing is wonky in
+# order to test space stripping. For everything, I'm trying to use the
+# non-default values.
+
+# Some things are in daemon-stdio-config{2,3}.txt instead:
+# - [directory] is xor [kafka] and global.topic-prefix
+# - kafka.sasl-password is xor kafka.sasl-password-file
 
 [global]
 cluster = mlx.hpc.uio.no
 role=node
+topic-prefix=zappa
 lock-directory= /root
   
+[kafka]
+broker-address = localhost:0000
+sending-window=1h
+timeout=1m
+ca-file=test-ca
+sasl-password-file=test-pass
+
+[debug]
+time-limit=10m
+output-delay=1m
+verbose=true
+
 [sample]
 cadence =5m
   batchless = true
 load = false  
 rollup = true
 min-cpu-time = 1m
+exclude-system-jobs = false
+exclude-users = bob,alice
+exclude-commands = ls,runuser
 
 [sysinfo]
 cadence = 24h
+on-startup = false
+topo-svg-command = hello
+topo-text-command = goodbye
 
 [slurm]
 cadence = 1h
 window = 90m
+batch-size=17
+uncompleted=true
+
+[cluster]
+cadence = 15m

--- a/src/testdata/daemon-stdio-config2.txt
+++ b/src/testdata/daemon-stdio-config2.txt
@@ -1,0 +1,13 @@
+# This is a valid test configuration, but only tests things that could
+# not be tested by daemon-stdio-config.txt.  See that file for more
+# information.
+
+[global]
+cluster = mlx.hpc.uio.no
+role=master
+
+[kafka]
+broker-address = localhost:0000
+sasl-password = qumquat
+ca-file = myfile
+

--- a/src/testdata/daemon-stdio-config3.txt
+++ b/src/testdata/daemon-stdio-config3.txt
@@ -1,0 +1,10 @@
+# This is a valid test configuration, but only tests things that could
+# not be tested by daemon-stdio-config.txt.  See that file for more
+# information.
+
+[global]
+cluster = fox.educloud.no
+role=master
+
+[directory]
+data-directory = /dev/null/your/data/here

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -33,6 +33,7 @@ tests="amd-gpu \
      rollup \
      rollup2 \
      regress-369-kafka-pump \
+     sacct-batching \
      sacct-parsing \
      sinfo-parsing \
      slurm-no-sacct \

--- a/tests/sacct-batching.sh
+++ b/tests/sacct-batching.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Check that `sonar slurm` output is batched correctly by comparing the non-batched output with the
+# catenated batched output, and by checking that no batch is larger than requested.
+
+source sh-helper
+assert cargo jq
+
+# Currently there are 301=43*7 input records, any batch size not those factors is OK.
+batch=17
+
+outfile1=tmp/sacct-batching1.tmp
+outfile2=tmp/sacct-batching2.tmp
+
+SONARTEST_MOCK_SACCT=testdata/sacct_output.txt \
+    SONARTEST_MOCK_SCONTROL=/dev/null \
+    cargo run -- slurm --deluge \
+    | jq '.data.attributes.slurm_jobs[]|[.job_id,.job_name,.job_state]' > $outfile1
+
+SONARTEST_MOCK_SACCT=testdata/sacct_output.txt \
+    SONARTEST_MOCK_SCONTROL=/dev/null \
+    cargo run -- slurm --deluge --batch-size $batch \
+    | jq '.data.attributes.slurm_jobs[]|[.job_id,.job_name,.job_state]' > $outfile2
+
+cmp $outfile1 $outfile2
+
+for n in $(SONARTEST_MOCK_SACCT=testdata/sacct_output.txt \
+               SONARTEST_MOCK_SCONTROL=/dev/null \
+               cargo run -- slurm --deluge --batch-size $batch \
+               | jq '.data.attributes.slurm_jobs|length'); do
+    if ((n > batch)); then
+        fail "Batch size is off: $n"
+    fi
+done
+
+echo " Ok"


### PR DESCRIPTION
Plus add some cases that were missing in the daemon parsing tests, since I was in there anyway.