### PR TITLE
Fix #433 - actually split output into messages

### DIFF
--- a/doc/HOWTO-DAEMON.md
+++ b/doc/HOWTO-DAEMON.md
@@ -177,6 +177,8 @@ cadence = <duration value>
 ```
 verbose = bool                                  # default false
 time-limit = <duration value>                   # default none
+oneshot = bool                                  # default false
+output-delay = <duration value>                 # default none
 ```
 
 Setting `verbose` to true will cause the daemon to print somewhat informative messages about what
@@ -185,6 +187,12 @@ it's doing at important points during the run to stderr.
 Setting `time-limit` to a duration will make the daemon exit after roughly that time (it may take
 longer, it will check the exit time before every sample, but not wake up from sleep just to handle
 the limit).
+
+Setting `oneshot` to true will cause the daemon to exit cleanly (and flush its output in the normal
+manner) after processing a single sonar operation.
+
+Setting `output-delay` to a duration will delay the first output until at least that much time
+has passed.
 
 ## DATA MESSAGE FORMATS
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -20,8 +20,10 @@ impl<'a> State<'a> {
         State { system, token }
     }
 
-    pub fn run(&mut self, writer: &mut dyn io::Write) {
-        show_cluster(writer, self.system, self.token.clone())
+    pub fn run(&mut self) -> Vec<Vec<u8>> {
+        let mut writer = Vec::new();
+        show_cluster(&mut writer, self.system, self.token.clone());
+        vec![writer]
     }
 }
 

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -55,8 +55,10 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn run(&mut self, writer: &mut dyn io::Write) {
-        do_create_snapshot(writer, self.system, &self.opts)
+    pub fn run(&mut self) -> Vec<Vec<u8>> {
+        let mut writer = Vec::new();
+        do_create_snapshot(&mut writer, self.system, &self.opts);
+        vec![writer]
     }
 }
 

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -35,15 +35,17 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn run(&mut self, writer: &mut dyn io::Write) {
+    pub fn run(&mut self) -> Vec<Vec<u8>> {
+        let mut writer = Vec::new();
         show_system(
-            writer,
+            &mut writer,
             self.system,
             self.token.clone(),
             Format::NewJSON,
             self.topo_svg_cmd.clone(),
             self.topo_text_cmd.clone(),
-        )
+        );
+        vec![writer]
     }
 }
 

--- a/tests/sacct-batching.sh
+++ b/tests/sacct-batching.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
-# Check that `sonar slurm` output is batched correctly by comparing the non-batched output with the
-# catenated batched output, and by checking that no batch is larger than requested.
+# Check that `sonar slurm` output is batched correctly in several ways:
+#
+# - by comparing the non-batched output with the catenated batched output
+# - by checking that no batch is larger than requested
+# - by counting output records in the daemon data sink via metadata and comparing it
+#   to the expected number of batches
 
 source sh-helper
 assert cargo jq
@@ -11,6 +15,8 @@ batch=17
 
 outfile1=$(tmpfile sacct-batching1)
 outfile2=$(tmpfile sacct-batching2)
+inifile=$(tmpfile sacct-batching-ini)
+logfile=$(tmpfile sacct-batching-log)
 
 SONARTEST_MOCK_SACCT=testdata/sacct_output.txt \
     SONARTEST_MOCK_SCONTROL=/dev/null \
@@ -24,13 +30,57 @@ SONARTEST_MOCK_SACCT=testdata/sacct_output.txt \
 
 cmp $outfile1 $outfile2
 
+expected_records=0
 for n in $(SONARTEST_MOCK_SACCT=testdata/sacct_output.txt \
                SONARTEST_MOCK_SCONTROL=/dev/null \
                cargo run -- slurm --deluge --batch-size $batch \
                | jq '.data.attributes.slurm_jobs|length'); do
+    expected_records=$((expected_records+1))
     if ((n > batch)); then
         fail "Batch size is off: $n"
     fi
 done
+
+# Test that the batches are broken into actual separate messages in the data sink and not just
+# catenated in the output; we can't tell from the above.
+#
+# Use the daemon's Kafka output path with SONARTEST_MOCK_KAFKA to force output to stdout and
+# metadata to stderr.  Force the input with SONARTEST_MOCK_{SACCT,SCONTROL} and force the daemon to
+# quit after one run with a debug setting.
+#
+# Note that any sending-window is OK here.  If we set it to 1s, say, then the timer will fire and
+# re-arm repeatedly because the timer fires before all the data can be sent, and the output will
+# reflect this.  But the data should all still be sent.  If we set the window to 10s instead then
+# there will typically be many fewer firings, because all the messages will be queued up before the
+# first firing (unless sonar randomly picks a short window for the first fire).
+
+cat > $inifile <<EOF
+[global]
+cluster=hpc.axis-of-eval.org
+role=master
+
+[debug]
+verbose = true
+oneshot = true
+
+[kafka]
+broker-address = no.such.host:0000
+sending-window = 10s
+
+[jobs]
+cadence=1s
+batch-size = 17
+EOF
+
+SONARTEST_MOCK_KAFKA=1 \
+    SONARTEST_MOCK_SACCT=testdata/sacct_output.txt \
+    SONARTEST_MOCK_SCONTROL=/dev/null \
+    cargo run -- daemon $inifile > /dev/null 2> $logfile
+
+actual_records=$(grep '^Info: Sending to topic: ' $logfile | wc -l)
+if ((actual_records != expected_records)); then
+    cat $logfile
+    fail "Wrong number of records sent, expected $expected_records got $actual_records"
+fi
 
 echo " Ok"


### PR DESCRIPTION
Actually not too horrifying - there's some plumbing so that the run() methods all return vectors of vectors of output, the subvectors representing individual messages.  Then some plumbing to fit that into existing code most places, only the slurmjobs module needs to use it.  Then code in the daemon to process each message, not just the one.  Then a debug setting for one-shot runs so that we can write a sensible test.  And then the test case.