### PR TITLE
Fix #450 - compute numa nodes and distances properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "sonar"
-version = "0.16.0"
+version = "0.16.1-devel"
 dependencies = [
  "base64",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonar"
-version = "0.16.0"
+version = "0.16.1-devel"
 edition = "2021"
 repository = "https://github.com/NordicHPC/sonar"
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,11 @@ relied upon.  Consumers should expect to see the "new" JSON format for new data,
 should ask for that format.
 
 
+## Changes in v0.16.1 (on `release_0_16`)
+
+* Bug 450 - compute distances correctly to avoid erroring out when NUMA nodes are fewer than sockets;
+  expose `numa_nodes` field on sysinfo for good measure.
+
 ## Changes in v0.16.0 (on `release_0_16`)
 
 * Bug 335 / Bug 415 - **BREAKING CHANGE.** The `cpu_util` field was not emitted properly, it should

--- a/doc/NEW-FORMAT.md
+++ b/doc/NEW-FORMAT.md
@@ -314,6 +314,11 @@ Operating system version (the `release` field of `struct utsname`)
 
 Architecture name (the `machine` field of `struct utsname`)
 
+#### **`numa_nodes`** uint64
+
+Number of NUMA nodes (frequently smaller than the number of sockets), zero if we can't
+compute it
+
 #### **`sockets`** NonzeroUint
 
 Number of CPU sockets
@@ -337,12 +342,12 @@ Primary memory in kilobytes
 #### **`topo_svg`** string
 
 Base64-encoded text output (SVG source text) of `lstopo` or similar, using the base64
-alphabet from RFC4648.
+alphabet from RFC4648
 
 #### **`topo_text`** string
 
 Base64-encoded text output (human-readable) of `hwloc-ls` or similar, using the base64
-alphabet from RFC4648.
+alphabet from RFC4648
 
 #### **`cards`** []SysinfoGpuCard
 
@@ -350,7 +355,8 @@ Per-card information
 
 #### **`distances`** [][]uint64
 
-Square matrix of standard NUMA node-to-node distances (normalized to 10 for self distance)
+Square matrix of standard NUMA node-to-node distances (normalized to 10 for self distance),
+empty if we can't compute it
 
 ### Type: `SysinfoGpuCard`
 

--- a/doc/types.spec.yaml
+++ b/doc/types.spec.yaml
@@ -101,6 +101,10 @@ SysinfoAttributes:
       type: 'NonemptyString'
       doc: >
         Architecture name (the `machine` field of `struct utsname`)
+    numa_nodes:
+      type: 'uint64'
+      doc: >
+        Number of NUMA nodes (frequently smaller than the number of sockets), zero if we can't compute it
     sockets:
       type: 'NonzeroUint'
       doc: >
@@ -124,11 +128,11 @@ SysinfoAttributes:
     topo_svg:
       type: 'string'
       doc: >
-        Base64-encoded text output (SVG source text) of `lstopo` or similar, using the base64 alphabet from RFC4648.
+        Base64-encoded text output (SVG source text) of `lstopo` or similar, using the base64 alphabet from RFC4648
     topo_text:
       type: 'string'
       doc: >
-        Base64-encoded text output (human-readable) of `hwloc-ls` or similar, using the base64 alphabet from RFC4648.
+        Base64-encoded text output (human-readable) of `hwloc-ls` or similar, using the base64 alphabet from RFC4648
     cards:
       type: '[]SysinfoGpuCard'
       doc: >
@@ -136,7 +140,7 @@ SysinfoAttributes:
     distances:
       type: '[][]uint64'
       doc: >
-        Square matrix of standard NUMA node-to-node distances (normalized to 10 for self distance)
+        Square matrix of standard NUMA node-to-node distances (normalized to 10 for self distance), empty if we can't compute it
 SysinfoGpuCard:
   fields:
     index:

--- a/src/json_tags.rs
+++ b/src/json_tags.rs
@@ -31,6 +31,7 @@ pub const SYSINFO_ATTRIBUTES_NODE: &str = "node"; // Hostname
 pub const SYSINFO_ATTRIBUTES_OS_NAME: &str = "os_name"; // NonemptyString
 pub const SYSINFO_ATTRIBUTES_OS_RELEASE: &str = "os_release"; // NonemptyString
 pub const SYSINFO_ATTRIBUTES_ARCHITECTURE: &str = "architecture"; // NonemptyString
+pub const SYSINFO_ATTRIBUTES_NUMA_NODES: &str = "numa_nodes"; // uint64
 pub const SYSINFO_ATTRIBUTES_SOCKETS: &str = "sockets"; // NonzeroUint
 pub const SYSINFO_ATTRIBUTES_CORES_PER_SOCKET: &str = "cores_per_socket"; // NonzeroUint
 pub const SYSINFO_ATTRIBUTES_THREADS_PER_CORE: &str = "threads_per_core"; // NonzeroUint

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -122,6 +122,7 @@ fn layout_sysinfo_newfmt(
     attrs.push_s(SYSINFO_ATTRIBUTES_NODE, node_info.node.clone());
     attrs.push_s(SYSINFO_ATTRIBUTES_OS_NAME, system.get_os_name());
     attrs.push_s(SYSINFO_ATTRIBUTES_OS_RELEASE, system.get_os_release());
+    attrs.push_u(SYSINFO_ATTRIBUTES_NUMA_NODES, node_info.numa_nodes);
     attrs.push_u(SYSINFO_ATTRIBUTES_SOCKETS, node_info.sockets);
     attrs.push_u(
         SYSINFO_ATTRIBUTES_CORES_PER_SOCKET,
@@ -326,6 +327,7 @@ struct NodeInfo {
     node: String,
     description: String,
     logical_cores: u64,
+    numa_nodes: u64,
     sockets: u64,
     cores_per_socket: u64,
     threads_per_core: u64,
@@ -409,6 +411,7 @@ fn compute_nodeinfo(system: &dyn systemapi::SystemAPI) -> Result<NodeInfo, Strin
             "{sockets}x{cores_per_socket}{ht} {model_name}, {mem_gb} GiB{gpu_desc}"
         ),
         logical_cores: (sockets * cores_per_socket * threads_per_core) as u64,
+        numa_nodes: distances.len() as u64,
         sockets: sockets as u64,
         cores_per_socket: cores_per_socket as u64,
         threads_per_core: threads_per_core as u64,

--- a/src/sysinfo_test.rs
+++ b/src/sysinfo_test.rs
@@ -14,15 +14,21 @@ use std::collections::HashMap;
 #[test]
 pub fn sysinfo_output_test() {
     // FIXME: Information leakage!!
-    let mut files = HashMap::new();
-    files.insert(
+    let mut proc_files = HashMap::new();
+    proc_files.insert(
         "cpuinfo".to_string(),
         std::include_str!("linux/testdata/cpuinfo-x86_64.txt").to_string(),
     );
-    files.insert(
+    proc_files.insert(
         "meminfo".to_string(),
         "MemTotal:       16093776 kB".to_string(),
     );
+    // Really we want something here where we have multiple nodes, but we *also* want sockets>nodes
+    // to test that bit.  However I don't want to change the test data on release_0_16 too much so
+    // for now let's be happy with sockets==nodes.
+    let mut node_files = HashMap::new();
+    node_files.insert("node0/distance".to_string(), "10 21".to_string());
+    node_files.insert("node1/distance".to_string(), "21 10".to_string());
     let system = mocksystem::Builder::new()
         .with_version("0.13.100")
         .with_timestamp("2025-02-11T08:47+01:00")
@@ -30,7 +36,8 @@ pub fn sysinfo_output_test() {
         .with_cluster("kain.uio.no")
         .with_os("CP/M", "2.2")
         .with_architecture("Z80")
-        .with_proc_files(files)
+        .with_proc_files(proc_files)
+        .with_node_files(node_files)
         .with_card(gpu::Card {
             bus_addr: "12:14:16".to_string(),
             device: gpu::Name {
@@ -97,13 +104,14 @@ pub fn sysinfo_output_test() {
 "node":"yes.no",
 "os_name":"CP/M",
 "os_release":"2.2",
+"numa_nodes":2,
 "sockets":2,
 "cores_per_socket":4,
 "threads_per_core":2,
 "cpu_model":"Intel(R) Xeon(R) CPU E5-2637 v4 @ 3.50GHz",
 "architecture":"Z80",
 "memory":16093776,
-"distances":[[10]],
+"distances":[[10,21],[21,10]],
 "cards":[
 {
 "index":0,

--- a/src/systemapi.rs
+++ b/src/systemapi.rs
@@ -62,6 +62,9 @@ pub trait SystemAPI {
     // and/or removed).
     fn compute_user_by_uid(&self, uid: u32) -> Option<String>;
 
+    // Read a file below /sys/devices/system/node, the filename must be a relative path.
+    fn read_node_file_to_string(&self, filename: &str) -> io::Result<String>;
+
     // Run sacct and return its output.  The arguments are passed on to sacct: `job_states` to `-s`,
     // `field_names` to `-o`, `from` to `-S` and `to` to `-E`.  This is only defined for state and
     // field names that exist, and for properly slurm-formatted dates.

--- a/util/formats/newfmt/types.go
+++ b/util/formats/newfmt/types.go
@@ -326,6 +326,10 @@ type SysinfoAttributes struct {
 	// Architecture name (the `machine` field of `struct utsname`)
 	Architecture NonemptyString `json:"architecture"`
 
+	// Number of NUMA nodes (frequently smaller than the number of sockets), zero if we can't
+	// compute it
+	NumaNodes uint64 `json:"numa_nodes"`
+
 	// Number of CPU sockets
 	Sockets NonzeroUint `json:"sockets"`
 
@@ -342,17 +346,18 @@ type SysinfoAttributes struct {
 	Memory NonzeroUint `json:"memory"`
 
 	// Base64-encoded text output (SVG source text) of `lstopo` or similar, using the base64
-	// alphabet from RFC4648.
+	// alphabet from RFC4648
 	TopoSVG string `json:"topo_svg,omitempty"`
 
 	// Base64-encoded text output (human-readable) of `hwloc-ls` or similar, using the base64
-	// alphabet from RFC4648.
+	// alphabet from RFC4648
 	TopoText string `json:"topo_text,omitempty"`
 
 	// Per-card information
 	Cards []SysinfoGpuCard `json:"cards,omitempty"`
 
-	// Square matrix of standard NUMA node-to-node distances (normalized to 10 for self distance)
+	// Square matrix of standard NUMA node-to-node distances (normalized to 10 for self distance),
+	// empty if we can't compute it
 	Distances [][]uint64 `json:"distances,omitempty"`
 }
 


### PR DESCRIPTION
OK, so strategy:

- look for the `distance` files for nodes up to numsockets-1
- if we find them, they should together make a square matrix
- and the number of nodes we found is exposed as a new numa_nodes field in the output
- if we don't find them, we do not error out but just return an empty value
