### PR TITLE
Fix #457 - grab processes running inside docker

### DIFF
--- a/doc/NEW-FORMAT.md
+++ b/doc/NEW-FORMAT.md
@@ -638,7 +638,8 @@ The job ID
 #### **`user`** NonemptyString
 
 User name on the cluster; `_user_<uid>` if not determined but user ID is available,
-`_user_unknown` otherwise.
+`_user_unknown` otherwise.  Notably in the case of container processes (see the "InContainer"
+flag in SampleProcess), the user may be nonsensical (unknown or wrong uid) or root.
 
 #### **`epoch`** uint64
 
@@ -701,6 +702,13 @@ Process ID, zero is used for rolled-up samples (see below at "Rolledup").
 #### **`ppid`** uint64
 
 Parent-process ID.
+
+#### **`in_container`** bool
+
+True if deemed a part of a container.  Notably, for docker this means it is a child of
+something whose name starts with "containerd" where that parent is itself a child of init.
+InContainer is a flag on the process and not on the job since it is possible for a job to
+fork off a container as part of its work but itself not be running in a container.
 
 #### **`num_threads`** uint64
 

--- a/doc/VERSIONING.md
+++ b/doc/VERSIONING.md
@@ -75,6 +75,7 @@ release:
 - on an arm64 node with no GPUs, run `make test`
 - on an x86_64 node with NVIDIA GPUs, run `make test`; the nvidia test should not say "No device"
 - on an x86_64 node with AMD GPUs, run `make test`; the amd test should not say "No device"
+- on a node with docker, run `make test` or `tests/docker*sh`; the test should not say "... skipping test" for any reason
 - on a node with a local Kafka install, go to `tests/kafka` and run the tests as described
   in `tests/kafka/README.md`
 

--- a/doc/types.spec.yaml
+++ b/doc/types.spec.yaml
@@ -350,7 +350,7 @@ SampleJob:
     user:
       type: 'NonemptyString'
       doc: >
-        User name on the cluster; `_user_<uid>` if not determined but user ID is available, `_user_unknown` otherwise.
+        User name on the cluster; `_user_<uid>` if not determined but user ID is available, `_user_unknown` otherwise.  Notably in the case of container processes (see the "InContainer" flag in SampleProcess), the user may be nonsensical (unknown or wrong uid) or root.
     epoch:
       type: 'uint64'
       doc: >
@@ -381,6 +381,10 @@ SampleProcess:
       type: 'uint64'
       doc: >
         Parent-process ID.
+    in_container:
+      type: 'bool'
+      doc: >
+        True if deemed a part of a container.  Notably, for docker this means it is a child of something whose name starts with "containerd" where that parent is itself a child of init. InContainer is a flag on the process and not on the job since it is possible for a job to fork off a container as part of its work but itself not be running in a container.
     num_threads:
       type: 'uint64'
       doc: >

--- a/src/json_tags.rs
+++ b/src/json_tags.rs
@@ -97,6 +97,7 @@ pub const SAMPLE_PROCESS_VIRTUAL_MEMORY: &str = "virtual_memory"; // uint64
 pub const SAMPLE_PROCESS_CMD: &str = "cmd"; // string
 pub const SAMPLE_PROCESS_PID: &str = "pid"; // uint64
 pub const SAMPLE_PROCESS_PARENT_PID: &str = "ppid"; // uint64
+pub const SAMPLE_PROCESS_IN_CONTAINER: &str = "in_container"; // bool
 pub const SAMPLE_PROCESS_NUM_THREADS: &str = "num_threads"; // uint64
 pub const SAMPLE_PROCESS_CPU_AVG: &str = "cpu_avg"; // float64
 pub const SAMPLE_PROCESS_CPU_UTIL: &str = "cpu_util"; // float64

--- a/src/ps_newfmt.rs
+++ b/src/ps_newfmt.rs
@@ -3,7 +3,7 @@
 use crate::gpu;
 use crate::json_tags::*;
 use crate::output;
-use crate::ps::{ProcInfo, PsOptions, SampleData};
+use crate::ps::{CState, ProcInfo, PsOptions, SampleData};
 use crate::systemapi;
 use crate::util::three_places;
 
@@ -188,6 +188,9 @@ fn format_newfmt_sample(proc_info: &ProcInfo) -> output::Object {
     }
     if proc_info.ppid != 0 {
         fields.push_u(SAMPLE_PROCESS_PARENT_PID, proc_info.ppid as u64);
+    }
+    if proc_info.container_state == CState::Child {
+        fields.push_b(SAMPLE_PROCESS_IN_CONTAINER, true);
     }
     if proc_info.num_threads != 0 {
         fields.push_u(SAMPLE_PROCESS_NUM_THREADS, proc_info.num_threads as u64);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,5 @@
 pincpu
+pincpus
 rollup
 rollup2
 rollupchild

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,4 +20,4 @@ rollupchild2: rollupchild
 
 # Same files as in .gitignore
 clean:
-	rm -rf pincpu rollup rollup2 rollupchild rollupchild2 tmp *~
+	rm -rf pincpu pincpus rollup rollup2 rollupchild rollupchild2 tmp *~

--- a/tests/docker-run.sh
+++ b/tests/docker-run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+source sh-helper
+guard docker
+guard_group docker
+
+output=$(tmpfile docker-out)
+selected=$(tmpfile docker-selected)
+
+echo " The test takes about 20s and may download a docker image"
+make pincpu pincpus
+cargo build
+
+# Single-process test.  The pincpu program should show up as being owned by root.
+
+docker run -d -v .:/sonar:z --rm -it ubuntu /sonar/pincpu 10
+
+sleep 5
+cargo run -- ps --exclude-system-jobs > $output
+
+jq -c '.data.attributes.jobs[] | {user, process: .processes[]} | select(.user == "root") | [.user, .process.cmd, .process.in_container]' $output > $selected
+if ! grep -q -F '["root","pincpu",true]' $selected; then
+    cat $selected
+    fail "Did not find pincpu process"
+fi
+
+# Let's hope this is enough to make the first one terminate
+
+sleep 5
+
+# Multi-process / process tree test.  The pincpus program runs in a docker, it forks off two pincpu
+# children with the same argument and then waits for them.  We should see all three in the docker
+# output as being marked as running in a container, and the children should have the parent as ppid.
+
+docker run -d -v .:/sonar:z --rm -it ubuntu /sonar/pincpus /sonar/pincpu 2 10
+
+sleep 5
+cargo run -- ps --exclude-system-jobs > $output
+
+# TODO: count two pincpu processes (assuming there's nobody else on the system)
+# TODO: pincpu processes should have pincpus process as parent
+
+jq -c '.data.attributes.jobs[] | {user, process: .processes[]} | select(.user == "root") | [.user, .process.cmd, .process.in_container]' $output > $selected
+if ! grep -q -F '["root","pincpu",true]' $selected; then
+    cat $selected
+    fail "Did not find pincpu process"
+fi
+if ! grep -q -F '["root","pincpus",true]' $selected; then
+    cat $selected
+    fail "Did not find pincpus process"
+fi
+
+echo " Ok"

--- a/tests/exclude-system-jobs.go
+++ b/tests/exclude-system-jobs.go
@@ -1,0 +1,46 @@
+// Subroutine for exclude-system-jobs.sh.
+//
+// Stdin is a series of JSON lines on the form [username,flagval,...] where flagval is null or true
+// and the user name is double-quoted.  We're checking that if the uid of the user is < 1000 then at
+// least one of the flagvals is true.  If a condition does not hold for a line then print the line
+// on stderr and exit(1).
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	var foundContained int
+	for scanner.Scan() {
+		xs := strings.Split(strings.Trim(scanner.Text(), "[]"), ",")
+		name := strings.Trim(xs[0], "\"")
+		u, err := user.Lookup(name)
+		if err != nil {
+			fmt.Printf("Warning: unknown user %s\n", name)
+			continue
+		}
+		var uid uint
+		fmt.Sscanf(u.Uid, "%d", &uid)
+		if uid >= 1000 {
+			continue
+		}
+		contained := false
+		for _, f := range xs[1:] {
+			contained = contained || f == "true"
+		}
+		if !contained {
+			fmt.Fprintln(os.Stderr, "System job without any container processes")
+			fmt.Fprintln(os.Stderr, scanner.Text())
+			os.Exit(1)
+		}
+		foundContained++
+	}
+	fmt.Printf(" System user jobs with container process: %d\n", foundContained)
+}

--- a/tests/pincpus.c
+++ b/tests/pincpus.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int num_children = 0, time_to_wait = 0;
+    if (argc == 4) {
+        num_children = atoi(argv[2]);
+        time_to_wait = atoi(argv[3]);
+    }
+    if (argc != 4 || num_children <= 0 || time_to_wait <= 0) {
+        fprintf(stderr, "Usage: pincpus subprogram-path num-children time-to-wait\n");
+        exit(2);
+    }
+    int i;
+    for (i = 0; i < num_children; i++) {
+        switch (fork()) {
+        case -1:
+            perror("fork");
+            exit(1);
+        case 0:
+            execl(argv[1], argv[1], argv[3], NULL);
+            perror("exec");
+            exit(1);
+        }
+    }
+    for (i = 0; i < num_children; i++) {
+        wait(NULL);
+    }
+    return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,6 +16,7 @@ tests="amd-gpu \
      daemon-directory \
      daemon-interrupt \
      daemon-kafka \
+     docker-run \
      exclude-commands \
      exclude-system-jobs \
      exclude-users \

--- a/tests/sh-helper
+++ b/tests/sh-helper
@@ -37,6 +37,33 @@ function assert() {
     done
 }
 
+function guard() {
+    while [[ -n $1 ]]; do
+        if [[ -z $(command -v $1) ]]; then
+            echo " No $1; skipping test"
+            exit 0
+        fi
+        shift 1
+    done
+}
+
+function guard_group() {
+    while [[ -n $1 ]]; do
+        in_group=0
+        for g in $(groups); do
+            if [[ $g == $1 ]]; then
+                in_group=1
+                break
+            fi
+        done
+        if ((in_group == 0)); then
+            echo " Not in group $1; skipping test"
+            exit 0
+        fi
+        shift 1
+    done
+}
+
 function join() {
     local xs=$1
     shift 1

--- a/util/formats/newfmt/types.go
+++ b/util/formats/newfmt/types.go
@@ -582,7 +582,8 @@ type SampleJob struct {
 	Job uint64 `json:"job"`
 
 	// User name on the cluster; `_user_<uid>` if not determined but user ID is available,
-	// `_user_unknown` otherwise.
+	// `_user_unknown` otherwise.  Notably in the case of container processes (see the "InContainer"
+	// flag in SampleProcess), the user may be nonsensical (unknown or wrong uid) or root.
 	User NonemptyString `json:"user"`
 
 	// Zero for batch jobs, otherwise is a nonzero value that increases (by some amount) when the
@@ -638,6 +639,12 @@ type SampleProcess struct {
 
 	// Parent-process ID.
 	ParentPid uint64 `json:"ppid,omitempty"`
+
+	// True if deemed a part of a container.  Notably, for docker this means it is a child of
+	// something whose name starts with "containerd" where that parent is itself a child of init.
+	// InContainer is a flag on the process and not on the job since it is possible for a job to
+	// fork off a container as part of its work but itself not be running in a container.
+	InContainer bool `json:"in_container,omitempty"`
 
 	// The number of threads in the process, minus 1 - we don't count the process's main thread
 	// (allowing this fields to be omitted in transmission for most processes).


### PR DESCRIPTION
This may or may not be done, not sure yet.  It will look for processes called "containerd*" whose ppid is 1, these are the roots of the containers.  Every child of those processes should be included even if --exclude-system-processes is true and the owner is some system uid.  This appears to work for both docker run and docker compose.

Obviously there may be false positives but they are unlikely (it is possible for a user to construct a process meeting the filtering criteria) and mostly benign.  We could consider performing the extra marking if there's at least some docker process running on the system.  Not sure it's worth the extra effort.

Processes in containers get assigned UIDs that are curious, it may be that they are cgroup-relative in some way - I've seen UID 100 and UID 1000 assigned to java processes running inside a container, both were wrong.