### PR TITLE
No bug - Kafka HTTP proxy dumps input with -D

### DIFF
--- a/util/kafka-proxy/.gitignore
+++ b/util/kafka-proxy/.gitignore
@@ -1,1 +1,2 @@
 kprox
+kafka-proxy.dat

--- a/util/kafka-proxy/testdata/README.md
+++ b/util/kafka-proxy/testdata/README.md
@@ -1,0 +1,11 @@
+# Proxy test data
+
+`test-payload.json` is a valid test input for the kafka proxy.  You can send it with
+
+```
+curl --data-binary @test-payload.json -H 'Content-Type: application/octet-stream' localhost:8090
+```
+
+and if the proxy is run with -D, the file `kafka-proxy.dat` will be equivalent to the input file,
+though not exactly the same because some newlines were lost in transit, by design, and the JSON
+formatting is a little different.


### PR DESCRIPTION
With -D the kafka http proxy will now dump its input to a file, not simply report that it has received input.

This is a testing feature, it does not affect existing production functionality.
