### PR TITLE
For #540 - Refactor http code for reuse

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1160,6 +1160,7 @@ fn parse_bool(context: &str, l: &str) -> Result<bool, String> {
     }
 }
 
+#[cfg(feature = "kafka")]
 fn parse_volume(context: &str, l: &str) -> Result<usize, String> {
     let (val, scale) = if let Some(prefix) = l.strip_suffix('K') {
         (prefix, 1024)

--- a/src/datasink/background.rs
+++ b/src/datasink/background.rs
@@ -1,0 +1,79 @@
+use crate::util::rng::Rng;
+use crossbeam::channel;
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub struct Msg {
+    pub timestamp: u64,
+    pub topic: String,
+    pub key: String,
+    pub value: String,
+}
+
+impl Msg {
+    // This can return an estimate, but it's better to overestimate than underestimate.
+    pub fn size(&self) -> usize {
+        return self.topic.len() + self.key.len() + self.value.len() + 20;
+    }
+}
+
+pub enum Message {
+    Stop,
+    M(Msg),
+}
+
+pub trait BackgroundSender {
+    fn send_all(&self, id: usize, msgs: Vec<Msg>);
+    fn shutdown_delay_ms(&self) -> usize;
+}
+
+pub fn background_producer(
+    sending_window: u64,
+    incoming_message_queue: channel::Receiver<Message>,
+    sender: &dyn BackgroundSender,
+) {
+    let mut id = 0usize;
+    let mut rng = Rng::new();
+    let mut timeout: channel::Receiver<Instant> = channel::never();
+    let mut armed = false;
+    let mut must_arm = false;
+    let mut backlog = Vec::new();
+
+    'producer_loop: loop {
+        if must_arm {
+            assert!(!armed);
+            let sleep = rng.next() as u64 % sending_window;
+            // Note, the /Sleeping {} before sending/ pattern is used by regression tests.
+            log::debug!("Sleeping {sleep} before sending");
+            timeout = channel::after(Duration::from_secs(sleep));
+            armed = true;
+            must_arm = false;
+        }
+        channel::select! {
+            recv(timeout) -> _ => {
+                armed = false;
+                // Note, the /Sending {} items/ pattern is used by regression tests.
+                log::debug!("Sending window open.  Sending {} items", backlog.len());
+                let num = backlog.len();
+                sender.send_all(id, backlog);
+                backlog = vec![];
+                id += num;
+            }
+            recv(incoming_message_queue) -> msg => match msg {
+                Ok(Message::M(msg)) => {
+                    backlog.push(msg);
+                    must_arm = !armed;
+                }
+                Ok(Message::Stop) | Err(_) => {
+                    if backlog.len() > 0 {
+                        _ = sender.send_all(id, backlog);
+                    }
+                    break 'producer_loop;
+                }
+            }
+        }
+    }
+
+    // Best effort: give the Kafka thread an opportunity to send what it has.
+    thread::sleep(Duration::from_millis(2 * sender.shutdown_delay_ms() as u64));
+}

--- a/src/datasink/background.rs
+++ b/src/datasink/background.rs
@@ -91,7 +91,7 @@ pub fn background_producer(
     }
 
     // Best effort: give the sending thread an opportunity to send what it has.
-    thread::sleep(Duration::from_millis(2 * sender.shutdown_delay_ms() as u64));
+    thread::sleep(Duration::from_millis(sender.shutdown_delay_ms() as u64));
 }
 
 // Send all messages in the backlog, but apply batching if appropriate.
@@ -105,13 +105,13 @@ fn send_all(
     if !backlog.is_empty() {
         // Note, the /Sending {} items/ pattern is used by regression tests.
         log::debug!("Sending {} items", backlog.len());
-        let (boverhead, moverhead) = sender.metadata_size();
+        let (batch_overhead, msg_overhead) = sender.metadata_size();
         if let Some(cutoff) = cutoff {
             while !backlog.is_empty() {
                 let mut i = 0;
-                let mut sz = boverhead;
+                let mut sz = batch_overhead;
                 while i < backlog.len() {
-                    let newsz = sz + backlog[i].size() + moverhead;
+                    let newsz = sz + backlog[i].size() + msg_overhead;
                     if newsz >= cutoff {
                         break;
                     }
@@ -123,7 +123,8 @@ fn send_all(
                         "Message of size {} is too large to send, should not happen",
                         backlog[0].size()
                     );
-                    // TODO: Must drop it or send it!!
+                    // Try to send it anyway, take the consequences elsewhere.
+                    i = 1;
                 }
                 let new_backlog = backlog.split_off(i);
                 let to_send = backlog;

--- a/src/datasink/background.rs
+++ b/src/datasink/background.rs
@@ -23,15 +23,29 @@ pub enum Message {
 }
 
 pub trait BackgroundSender {
+    // Send all the messages in msgs, together if possible (batching is done at a higher level).
     fn send_all(&self, id: usize, msgs: Vec<Msg>);
+
+    // How long to wait for a backgrounded sender to send things when shutting down Sonar, may be
+    // zero.
     fn shutdown_delay_ms(&self) -> usize;
+
+    // Estimated size of metadata in bytes, when batching: per-batch and per-message.  If batching
+    // is disabled (cutoff is zero) then this will not be called, but otherwise it should
+    // conservatively estimate the size of the message metadata.
+    fn metadata_size(&self) -> (usize, usize);
 }
 
+// Call background_producer from a dedicated producer thread (or spawn it as a thread).  It will
+// loop on the incoming message queue until it receives a stop message.  The messages received are
+// held for a suitable random interval and then sent.
 pub fn background_producer(
+    cutoff: Option<usize>,
     sending_window: u64,
     incoming_message_queue: channel::Receiver<Message>,
     sender: &dyn BackgroundSender,
 ) {
+    let sending_window = if sending_window == 0 { 1 } else { sending_window };
     let mut id = 0usize;
     let mut rng = Rng::new();
     let mut timeout: channel::Receiver<Instant> = channel::never();
@@ -52,10 +66,9 @@ pub fn background_producer(
         channel::select! {
             recv(timeout) -> _ => {
                 armed = false;
-                // Note, the /Sending {} items/ pattern is used by regression tests.
-                log::debug!("Sending window open.  Sending {} items", backlog.len());
+                log::debug!("Sending window open.");
                 let num = backlog.len();
-                sender.send_all(id, backlog);
+                send_all(sender, cutoff, id, backlog);
                 backlog = vec![];
                 id += num;
             }
@@ -65,15 +78,52 @@ pub fn background_producer(
                     must_arm = !armed;
                 }
                 Ok(Message::Stop) | Err(_) => {
-                    if backlog.len() > 0 {
-                        _ = sender.send_all(id, backlog);
-                    }
+                    send_all(sender, cutoff, id, backlog);
                     break 'producer_loop;
                 }
             }
         }
     }
 
-    // Best effort: give the Kafka thread an opportunity to send what it has.
+    // Best effort: give the sending thread an opportunity to send what it has.
     thread::sleep(Duration::from_millis(2 * sender.shutdown_delay_ms() as u64));
+}
+
+// Send all messages in the backlog, but apply batching if appropriate.
+// Note backlog length may be zero, do nothing if so.
+fn send_all(sender: &dyn BackgroundSender, cutoff: Option<usize>, mut id: usize, mut backlog: Vec<Msg>) {
+    if backlog.len() > 0 {
+        // Note, the /Sending {} items/ pattern is used by regression tests.
+        log::debug!("Sending {} items", backlog.len());
+        let (boverhead, moverhead) = sender.metadata_size();
+        if let Some(cutoff) = cutoff {
+            while backlog.len() > 0 {
+                let mut i = 0;
+                let mut sz = boverhead;
+                while i < backlog.len() {
+                    let newsz = sz + backlog[i].size() + moverhead;
+                    if newsz >= cutoff {
+                        break;
+                    }
+                    sz = newsz;
+                    i += 1;
+                }
+                if i == 0 {
+                    log::error!(
+                        "Message of size {} is too large to send, should not happen",
+                        backlog[0].size()
+                    );
+                    // TODO: Must drop it or send it!!
+                }
+                let new_backlog = backlog.split_off(i);
+                let to_send = backlog;
+                let num_sent = to_send.len();
+                backlog = new_backlog;
+                sender.send_all(id, to_send);
+                id += num_sent;
+            }
+        } else {
+            sender.send_all(id, backlog);
+        }
+    }
 }

--- a/src/datasink/background.rs
+++ b/src/datasink/background.rs
@@ -14,7 +14,7 @@ pub struct Msg {
 impl Msg {
     // This can return an estimate, but it's better to overestimate than underestimate.
     pub fn size(&self) -> usize {
-        return self.topic.len() + self.key.len() + self.value.len() + 20;
+        self.topic.len() + self.key.len() + self.value.len() + 20
     }
 }
 
@@ -102,12 +102,12 @@ fn send_all(
     mut id: usize,
     mut backlog: Vec<Msg>,
 ) {
-    if backlog.len() > 0 {
+    if !backlog.is_empty() {
         // Note, the /Sending {} items/ pattern is used by regression tests.
         log::debug!("Sending {} items", backlog.len());
         let (boverhead, moverhead) = sender.metadata_size();
         if let Some(cutoff) = cutoff {
-            while backlog.len() > 0 {
+            while !backlog.is_empty() {
                 let mut i = 0;
                 let mut sz = boverhead;
                 while i < backlog.len() {

--- a/src/datasink/background.rs
+++ b/src/datasink/background.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 pub struct Msg {
+    #[allow(unused)]
     pub timestamp: u64,
     pub topic: String,
     pub key: String,
@@ -45,7 +46,11 @@ pub fn background_producer(
     incoming_message_queue: channel::Receiver<Message>,
     sender: &dyn BackgroundSender,
 ) {
-    let sending_window = if sending_window == 0 { 1 } else { sending_window };
+    let sending_window = if sending_window == 0 {
+        1
+    } else {
+        sending_window
+    };
     let mut id = 0usize;
     let mut rng = Rng::new();
     let mut timeout: channel::Receiver<Instant> = channel::never();
@@ -91,7 +96,12 @@ pub fn background_producer(
 
 // Send all messages in the backlog, but apply batching if appropriate.
 // Note backlog length may be zero, do nothing if so.
-fn send_all(sender: &dyn BackgroundSender, cutoff: Option<usize>, mut id: usize, mut backlog: Vec<Msg>) {
+fn send_all(
+    sender: &dyn BackgroundSender,
+    cutoff: Option<usize>,
+    mut id: usize,
+    mut backlog: Vec<Msg>,
+) {
     if backlog.len() > 0 {
         // Note, the /Sending {} items/ pattern is used by regression tests.
         log::debug!("Sending {} items", backlog.len());

--- a/src/datasink/http_upload.rs
+++ b/src/datasink/http_upload.rs
@@ -3,30 +3,43 @@ use std::io::{Read, Write};
 
 use crossbeam::channel;
 
-// The abstraction here will be a "http poster" that encapsulates the sending method and a bunch of
-// the other stuff, and into which we can pump a bunch of data.  Then it does not matter if that
-// uses curl or some other method.  The http poster can be shared between the kafka code and the
-// pure http POST code, and has the same general shape as the kafka poster code.
-
+// A simple back-end that will HTTP POST some data to an endpoint, while handling proxies and
+// timeouts.
 pub struct HttpUploader<'a> {
     curl_cmd: &'a str,
     api_endpoint: &'a str,
     http_proxy: &'a str,
-    timeout: u64,
+    retry_count: i32,
 }
 
 impl<'a> HttpUploader<'a> {
+    // Create the uploader.  Using the provided curl_cmd, it will POST data to the given
+    // api_endpoint, possibly via the given http_proxy, retrying periodically until timeout seconds
+    // have elapsed.  After creating the uploader, call start() to fork off a curl process that will
+    // perform the upload; this is represented by the returned HttpUploadStream.  Call put()
+    // repeatedly on the stream to send data, and finally end() to close down the upload.  It is
+    // possible to call start() repeatedly on the same uploader, it will create independent
+    // subprocesses and threads to handle the additional uploads, all of which will be performed
+    // concurrently.
     pub fn new(
         curl_cmd: &'a str,
         api_endpoint: &'a str,
         http_proxy: &'a str,
-        timeout: u64,
+        mut timeout: u64,
     ) -> HttpUploader<'a> {
+        // Curl will retry for 1s, 2s, 4s, ..., 10m and then stick to 10m
+        let mut retry_count = 0;
+        let mut next = 1;
+        while timeout > 0 {
+            timeout -= min(next, timeout);
+            next = min(600, next * 2);
+            retry_count += 1;
+        }
         HttpUploader {
             curl_cmd,
             api_endpoint,
             http_proxy,
-            timeout,
+            retry_count,
         }
     }
 
@@ -35,16 +48,6 @@ impl<'a> HttpUploader<'a> {
         // send the output and handle retries, it will automatically pick up proxy settings from the
         // environment.  The main thread does not wait for it to finish but spins up threads to
         // handle its stdin/stdout/stderr and the final wait.
-
-        // Curl will retry for 1s, 2s, 4s, ..., 10m and then stick to 10m
-        let mut retry_count = 0;
-        let mut next = 1;
-        let mut timeout = self.timeout;
-        while timeout > 0 {
-            timeout -= min(next, timeout);
-            next = min(600, next * 2);
-            retry_count += 1;
-        }
         let mut args = vec![
             "--silent".to_string(),
             "--show-error".to_string(),
@@ -53,9 +56,9 @@ impl<'a> HttpUploader<'a> {
             "-H".to_string(),
             "Content-Type: application/octet-stream".to_string(),
         ];
-        if retry_count > 0 {
+        if self.retry_count > 0 {
             args.push("--retry".to_string());
-            args.push(format!("{}", retry_count));
+            args.push(format!("{}", self.retry_count));
             args.push("--retry-connrefused".to_string());
         }
         args.push(self.api_endpoint.to_string());
@@ -82,7 +85,10 @@ impl<'a> HttpUploader<'a> {
                     Err("Failed to get stdin/stdout/stderr".to_string())
                 }
             }
-            Err(e) => Err(format!("Failed to spawn curl: {:?}", e)),
+            Err(e) => {
+                // Note, tests depend on this error message
+                Err(format!("Failed to launch curl: {:?}", e))
+            }
         }
     }
 }

--- a/src/datasink/http_upload.rs
+++ b/src/datasink/http_upload.rs
@@ -1,5 +1,5 @@
-use std::io::{Read, Write};
 use std::cmp::min;
+use std::io::{Read, Write};
 
 use crossbeam::channel;
 
@@ -16,8 +16,13 @@ pub struct HttpUploader<'a> {
 }
 
 impl<'a> HttpUploader<'a> {
-    pub fn new(curl_cmd: &'a str, api_endpoint: &'a str, http_proxy: &'a str, timeout: u64) -> HttpUploader<'a> {
-        HttpUploader{
+    pub fn new(
+        curl_cmd: &'a str,
+        api_endpoint: &'a str,
+        http_proxy: &'a str,
+        timeout: u64,
+    ) -> HttpUploader<'a> {
+        HttpUploader {
             curl_cmd,
             api_endpoint,
             http_proxy,
@@ -77,9 +82,7 @@ impl<'a> HttpUploader<'a> {
                     Err("Failed to get stdin/stdout/stderr".to_string())
                 }
             }
-            Err(e) => {
-                Err(format!("Failed to spawn curl: {:?}", e))
-            }
+            Err(e) => Err(format!("Failed to spawn curl: {:?}", e)),
         }
     }
 }
@@ -88,7 +91,11 @@ pub struct HttpUploadStream {
     sending: channel::Sender<Option<String>>,
 }
 
-// FIXME: This needs a drop() thing that calls end().
+impl Drop for HttpUploadStream {
+    fn drop(&mut self) {
+        let _ = self.end();
+    }
+}
 
 impl HttpUploadStream {
     fn start(
@@ -180,7 +187,7 @@ impl HttpUploadStream {
             let _ = child.wait();
         }));
 
-        HttpUploadStream{sending}
+        HttpUploadStream { sending }
     }
 
     pub fn put_string(&self, s: String) {

--- a/src/datasink/http_upload.rs
+++ b/src/datasink/http_upload.rs
@@ -1,27 +1,37 @@
 use std::cmp::min;
-use std::io::{Read, Write};
-use std::thread;
-use std::time::{Duration, Instant};
-
-use crossbeam::channel;
 
 // The abstraction here will be a "http poster" that encapsulates the sending method and a bunch of
 // the other stuff, and into which we can pump a bunch of data.  Then it does not matter if that
 // uses curl or some other method.  The http poster can be shared between the kafka code and the
 // pure http POST code, and has the same general shape as the kafka poster code.
 
-struct HttpUploader {
-    curl_cmd: &str,
-    api_endpoint: &str,
-    http_proxy: &str,
+pub struct HttpUploader<'a> {
+    curl_cmd: &'a str,
+    api_endpoint: &'a str,
+    http_proxy: &'a str,
     timeout: u64,
 }
 
-impl HttpUploader {
-    fn start(&self) -> Result<HttpUploadStream, String> {
+impl<'a> HttpUploader<'a> {
+    pub fn new(curl_cmd: &'a str, api_endpoint: &'a str, http_proxy: &'a str, timeout: u64) -> HttpUploader<'a> {
+        HttpUploader{
+            curl_cmd,
+            api_endpoint,
+            http_proxy,
+            timeout,
+        }
+    }
+
+    pub fn start(&self) -> Result<HttpUploadStream, String> {
+        // For now, the logic here is that to send a data package we fork off a curl and make it
+        // send the output and handle retries, it will automatically pick up proxy settings from the
+        // environment.  The main thread does not wait for it to finish but spins up threads to
+        // handle its stdin/stdout/stderr and the final wait.
+
         // Curl will retry for 1s, 2s, 4s, ..., 10m and then stick to 10m
         let mut retry_count = 0;
         let mut next = 1;
+        let mut timeout = self.timeout;
         while timeout > 0 {
             timeout -= min(next, timeout);
             next = min(600, next * 2);
@@ -40,25 +50,25 @@ impl HttpUploader {
             args.push(format!("{}", retry_count));
             args.push("--retry-connrefused".to_string());
         }
-        args.push(api_endpoint.to_string());
+        args.push(self.api_endpoint.to_string());
 
-        // Really want to merge stdout and stderr
-        let mut cmd = std::process::Command::new(cmd_name);
-        log::debug!("Curl: {cmd_name} {:?}", args);
+        // Really want to merge stdout and stderr if we can.
+        let mut cmd = std::process::Command::new(self.curl_cmd);
+        log::debug!("Curl: {} {:?}", self.curl_cmd, args);
         cmd.args(args)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
-        if http_proxy != "" {
-            cmd.env("http_proxy", http_proxy)
-                .env("https_proxy", http_proxy);
+        if self.http_proxy != "" {
+            cmd.env("http_proxy", self.http_proxy)
+                .env("https_proxy", self.http_proxy);
         }
         match cmd.spawn() {
             Ok(mut child) => {
-                if let (Some(mut stdin), Some(mut stdout), Some(mut stderr)) =
+                if let (Some(stdin), Some(stdout), Some(stderr)) =
                     (child.stdin.take(), child.stdout.take(), child.stderr.take())
                 {
-                    Ok(HttpUploadStream{child, stdin, stdout, stderr, ...})
+                    HttpUploadStream::start(child, stdin, stdout, stderr)
                 } else {
                     // Should never happen, probably
                     Err("Failed to get stdin/stdout/stderr".to_string())
@@ -71,100 +81,107 @@ impl HttpUploader {
     }
 }
 
-struct HttpUploadStream {
-    // child, stdin, stdout, stderr
+pub struct HttpUploadStream {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: std::process::ChildStdout,
+    stderr: std::process::ChildStderr,
 }
+
+// There will be a writer thread, two reader threads, and a waiter thread.  It's possible there
+// must be a queue sending data, in which case this becomes a copy - not what I want, but I can
+// live with it.  Probably we can arrange for bytes to be moved instead.
+
+// This needs a drop() thing that calls end().  Is end() even required?
 
 impl HttpUploadStream {
-    fn new(...) {
-    }
+    fn start(
+        child: std::process::Child,
+        stdin: std::process::ChildStdin,
+        stdout: std::process::ChildStdout,
+        stderr: std::process::ChildStderr,
+    ) {
+        // Writer thread
+        drop(std::thread::spawn(move || {
+            // get byte blobs from stream and write them to stdin.  There must be a signal for this
+            // to exit, otherwise nothing will work.  So end() should send an empty array or something.
+            for ... {
+                if let Err(err) = stdin.write_all(ctrl.as_bytes()) {
+                    log::debug!("Failed to write control object: {:?}", err);
+                }
+                if let Err(err) = stdin.write_all(value.as_bytes()) {
+                    log::debug!("Failed to write data blob size {data_size}: {:?}", err);
+                }
+            }
+            // Does this happen too soon?  As in, if there's enough data, will the consumer
+            // not have finished consuming?  Or will it just flush things and all will be fine?
+            drop(stdin);
+        }));
 
-    fn put(...) {
-    }
+        // Separate threads do the output consuming and waiting for curl to finish, in order to
+        // guarantee several things:
+        //
+        //  - if the curl does not terminate immediately (because it is retrying, not
+        //    reaching the host, bandwidth-limited, ...) then Sonar does not hang waiting
+        //    for it, but can get on with its work.
+        //  - curl will not block writing its output on a full pipe
+        //  - sonar will not block on writing to curl because curl is blocked
+        //  - the child does not linger once it's ready to exit
+        //
+        // We can't use wait_with_output() because that will close stdin, and we can't wait
+        // to fork off these thread until writing has completed.  We could maybe combine the
+        // two reader threads into one using some kind of nonblocking I/O.  Maybe there are
+        // other tricks.
+        //
+        // 1K buffer is enough to see interesting errors.
 
-    fn end(...) {
-    }
-}
-
-// This needs to be figured out somehow but it's a complex of threads that handles i/o and waits on
-// the child.
-
-            drop(std::thread::spawn(move || {
-                // get byte blobs from stream and write them to stdin
-                for ... {
-                    if let Err(err) = stdin.write_all(ctrl.as_bytes()) {
-                        log::debug!("Failed to write control object: {:?}", err);
+        drop(std::thread::spawn(move || {
+            let mut buf = [0; 1024];
+            loop {
+                match stdout.read(&mut buf[..]) {
+                    Err(_) | Ok(0) => {
+                        break;
                     }
-                    if let Err(err) = stdin.write_all(value.as_bytes()) {
-                        log::debug!("Failed to write data blob size {data_size}: {:?}", err);
+                    Ok(n) => {
+                        // This is the common case even when curl fails to deliver when
+                        // the server rejects the message.
+                        log::debug!(
+                            "Curl succeeded with output: {}",
+                            String::from_utf8_lossy(&buf[..n])
+                        );
                     }
                 }
-                // Does this happen too soon?  As in, if there's enough data, will the consumer
-                // not have finished consuming?  Or will it just flush things and all will be fine?
-                drop(stdin);
-            }));
-                // Separate threads do the output consuming and waiting for curl to finish, in order to
-                // guarantee several things:
-                //
-                //  - if the curl does not terminate immediately (because it is retrying, not
-                //    reaching the host, bandwidth-limited, ...) then Sonar does not hang waiting
-                //    for it, but can get on with its work.
-                //  - curl will not block writing its output on a full pipe
-                //  - sonar will not block on writing to curl because curl is blocked
-                //  - the child does not linger once it's ready to exit
-                //
-                // We can't use wait_with_output() because that will close stdin, and we can't wait
-                // to fork off these thread until writing has completed.  We could maybe combine the
-                // two reader threads into one using some kind of nonblocking I/O.  Maybe there are
-                // other tricks.
-                //
-                // 1K buffer is enough to see interesting errors.
-                drop(std::thread::spawn(move || {
-                    let mut buf = [0; 1024];
-                    loop {
-                        match stdout.read(&mut buf[..]) {
-                            Err(_) | Ok(0) => {
-                                break;
-                            }
-                            Ok(n) => {
-                                // This is the common case even when curl fails to deliver when
-                                // the server rejects the message.
-                                log::debug!(
-                                    "Curl succeeded with output: {}",
-                                    String::from_utf8_lossy(&buf[..n])
-                                );
-                            }
-                        }
-                    }
-                    drop(stdout);
-                }));
-                drop(std::thread::spawn(move || {
-                    let mut buf = [0; 1024];
-                    loop {
-                        match stderr.read(&mut buf[..]) {
-                            Err(_) | Ok(0) => {
-                                break;
-                            }
-                            Ok(n) => {
-                                log::debug!(
-                                    "Curl failed with output {}",
-                                    String::from_utf8_lossy(&buf[..n])
-                                );
-                            }
-                        }
-                    }
-                    drop(stderr);
-                }));
-                drop(std::thread::spawn(move || {
-                    let _ = child.wait();
-                }));
-            } else {
-                // Should never happen
-                let _ = control_and_errors.send(Operation::MessageDeliveryError(
-                    "Failed to get stdin/stdout/stderr".to_string(),
-                ));
             }
-        }
+            drop(stdout);
+        }));
+
+        drop(std::thread::spawn(move || {
+            let mut buf = [0; 1024];
+            loop {
+                match stderr.read(&mut buf[..]) {
+                    Err(_) | Ok(0) => {
+                        break;
+                    }
+                    Ok(n) => {
+                        log::debug!(
+                            "Curl failed with output {}",
+                            String::from_utf8_lossy(&buf[..n])
+                        );
+                    }
+                }
+            }
+            drop(stderr);
+        }));
+
+        drop(std::thread::spawn(move || {
+            let _ = child.wait();
+        }));
+    }
+
+    pub fn put(&self, _bytes: &[u8]) {
+    }
+
+    pub fn end(&self) -> Result<(), String> {
+        Ok(())
+    }
 }
-
-

--- a/src/datasink/http_upload.rs
+++ b/src/datasink/http_upload.rs
@@ -1,4 +1,7 @@
+use std::io::{Read, Write};
 use std::cmp::min;
+
+use crossbeam::channel;
 
 // The abstraction here will be a "http poster" that encapsulates the sending method and a bunch of
 // the other stuff, and into which we can pump a bunch of data.  Then it does not matter if that
@@ -68,7 +71,7 @@ impl<'a> HttpUploader<'a> {
                 if let (Some(stdin), Some(stdout), Some(stderr)) =
                     (child.stdin.take(), child.stdout.take(), child.stderr.take())
                 {
-                    HttpUploadStream::start(child, stdin, stdout, stderr)
+                    Ok(HttpUploadStream::start(child, stdin, stdout, stderr))
                 } else {
                     // Should never happen, probably
                     Err("Failed to get stdin/stdout/stderr".to_string())
@@ -82,35 +85,35 @@ impl<'a> HttpUploader<'a> {
 }
 
 pub struct HttpUploadStream {
-    child: std::process::Child,
-    stdin: std::process::ChildStdin,
-    stdout: std::process::ChildStdout,
-    stderr: std::process::ChildStderr,
+    sending: channel::Sender<Option<String>>,
 }
 
-// There will be a writer thread, two reader threads, and a waiter thread.  It's possible there
-// must be a queue sending data, in which case this becomes a copy - not what I want, but I can
-// live with it.  Probably we can arrange for bytes to be moved instead.
-
-// This needs a drop() thing that calls end().  Is end() even required?
+// FIXME: This needs a drop() thing that calls end().
 
 impl HttpUploadStream {
     fn start(
-        child: std::process::Child,
-        stdin: std::process::ChildStdin,
-        stdout: std::process::ChildStdout,
-        stderr: std::process::ChildStderr,
-    ) {
+        mut child: std::process::Child,
+        mut stdin: std::process::ChildStdin,
+        mut stdout: std::process::ChildStdout,
+        mut stderr: std::process::ChildStderr,
+    ) -> HttpUploadStream {
+        let (sending, receiving) = channel::unbounded::<Option<String>>();
+
         // Writer thread
+
         drop(std::thread::spawn(move || {
             // get byte blobs from stream and write them to stdin.  There must be a signal for this
             // to exit, otherwise nothing will work.  So end() should send an empty array or something.
-            for ... {
-                if let Err(err) = stdin.write_all(ctrl.as_bytes()) {
-                    log::debug!("Failed to write control object: {:?}", err);
-                }
-                if let Err(err) = stdin.write_all(value.as_bytes()) {
-                    log::debug!("Failed to write data blob size {data_size}: {:?}", err);
+            loop {
+                match receiving.recv() {
+                    Ok(Some(payload)) => {
+                        if let Err(err) = stdin.write_all(payload.as_bytes()) {
+                            log::debug!("Failed to write payload: {:?}", err);
+                        }
+                    }
+                    Ok(None) | Err(_) => {
+                        break;
+                    }
                 }
             }
             // Does this happen too soon?  As in, if there's enough data, will the consumer
@@ -129,7 +132,7 @@ impl HttpUploadStream {
         //  - the child does not linger once it's ready to exit
         //
         // We can't use wait_with_output() because that will close stdin, and we can't wait
-        // to fork off these thread until writing has completed.  We could maybe combine the
+        // to fork off these threads until writing has completed.  We could maybe combine the
         // two reader threads into one using some kind of nonblocking I/O.  Maybe there are
         // other tricks.
         //
@@ -176,12 +179,16 @@ impl HttpUploadStream {
         drop(std::thread::spawn(move || {
             let _ = child.wait();
         }));
+
+        HttpUploadStream{sending}
     }
 
-    pub fn put(&self, _bytes: &[u8]) {
+    pub fn put_string(&self, s: String) {
+        let _ = self.sending.send(Some(s));
     }
 
     pub fn end(&self) -> Result<(), String> {
+        let _ = self.sending.send(None);
         Ok(())
     }
 }

--- a/src/datasink/http_upload.rs
+++ b/src/datasink/http_upload.rs
@@ -1,0 +1,170 @@
+use std::cmp::min;
+use std::io::{Read, Write};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crossbeam::channel;
+
+// The abstraction here will be a "http poster" that encapsulates the sending method and a bunch of
+// the other stuff, and into which we can pump a bunch of data.  Then it does not matter if that
+// uses curl or some other method.  The http poster can be shared between the kafka code and the
+// pure http POST code, and has the same general shape as the kafka poster code.
+
+struct HttpUploader {
+    curl_cmd: &str,
+    api_endpoint: &str,
+    http_proxy: &str,
+    timeout: u64,
+}
+
+impl HttpUploader {
+    fn start(&self) -> Result<HttpUploadStream, String> {
+        // Curl will retry for 1s, 2s, 4s, ..., 10m and then stick to 10m
+        let mut retry_count = 0;
+        let mut next = 1;
+        while timeout > 0 {
+            timeout -= min(next, timeout);
+            next = min(600, next * 2);
+            retry_count += 1;
+        }
+        let mut args = vec![
+            "--silent".to_string(),
+            "--show-error".to_string(),
+            "--data-binary".to_string(),
+            "@-".to_string(),
+            "-H".to_string(),
+            "Content-Type: application/octet-stream".to_string(),
+        ];
+        if retry_count > 0 {
+            args.push("--retry".to_string());
+            args.push(format!("{}", retry_count));
+            args.push("--retry-connrefused".to_string());
+        }
+        args.push(api_endpoint.to_string());
+
+        // Really want to merge stdout and stderr
+        let mut cmd = std::process::Command::new(cmd_name);
+        log::debug!("Curl: {cmd_name} {:?}", args);
+        cmd.args(args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        if http_proxy != "" {
+            cmd.env("http_proxy", http_proxy)
+                .env("https_proxy", http_proxy);
+        }
+        match cmd.spawn() {
+            Ok(mut child) => {
+                if let (Some(mut stdin), Some(mut stdout), Some(mut stderr)) =
+                    (child.stdin.take(), child.stdout.take(), child.stderr.take())
+                {
+                    Ok(HttpUploadStream{child, stdin, stdout, stderr, ...})
+                } else {
+                    // Should never happen, probably
+                    Err("Failed to get stdin/stdout/stderr".to_string())
+                }
+            }
+            Err(e) => {
+                Err(format!("Failed to spawn curl: {:?}", e))
+            }
+        }
+    }
+}
+
+struct HttpUploadStream {
+    // child, stdin, stdout, stderr
+}
+
+impl HttpUploadStream {
+    fn new(...) {
+    }
+
+    fn put(...) {
+    }
+
+    fn end(...) {
+    }
+}
+
+// This needs to be figured out somehow but it's a complex of threads that handles i/o and waits on
+// the child.
+
+            drop(std::thread::spawn(move || {
+                // get byte blobs from stream and write them to stdin
+                for ... {
+                    if let Err(err) = stdin.write_all(ctrl.as_bytes()) {
+                        log::debug!("Failed to write control object: {:?}", err);
+                    }
+                    if let Err(err) = stdin.write_all(value.as_bytes()) {
+                        log::debug!("Failed to write data blob size {data_size}: {:?}", err);
+                    }
+                }
+                // Does this happen too soon?  As in, if there's enough data, will the consumer
+                // not have finished consuming?  Or will it just flush things and all will be fine?
+                drop(stdin);
+            }));
+                // Separate threads do the output consuming and waiting for curl to finish, in order to
+                // guarantee several things:
+                //
+                //  - if the curl does not terminate immediately (because it is retrying, not
+                //    reaching the host, bandwidth-limited, ...) then Sonar does not hang waiting
+                //    for it, but can get on with its work.
+                //  - curl will not block writing its output on a full pipe
+                //  - sonar will not block on writing to curl because curl is blocked
+                //  - the child does not linger once it's ready to exit
+                //
+                // We can't use wait_with_output() because that will close stdin, and we can't wait
+                // to fork off these thread until writing has completed.  We could maybe combine the
+                // two reader threads into one using some kind of nonblocking I/O.  Maybe there are
+                // other tricks.
+                //
+                // 1K buffer is enough to see interesting errors.
+                drop(std::thread::spawn(move || {
+                    let mut buf = [0; 1024];
+                    loop {
+                        match stdout.read(&mut buf[..]) {
+                            Err(_) | Ok(0) => {
+                                break;
+                            }
+                            Ok(n) => {
+                                // This is the common case even when curl fails to deliver when
+                                // the server rejects the message.
+                                log::debug!(
+                                    "Curl succeeded with output: {}",
+                                    String::from_utf8_lossy(&buf[..n])
+                                );
+                            }
+                        }
+                    }
+                    drop(stdout);
+                }));
+                drop(std::thread::spawn(move || {
+                    let mut buf = [0; 1024];
+                    loop {
+                        match stderr.read(&mut buf[..]) {
+                            Err(_) | Ok(0) => {
+                                break;
+                            }
+                            Ok(n) => {
+                                log::debug!(
+                                    "Curl failed with output {}",
+                                    String::from_utf8_lossy(&buf[..n])
+                                );
+                            }
+                        }
+                    }
+                    drop(stderr);
+                }));
+                drop(std::thread::spawn(move || {
+                    let _ = child.wait();
+                }));
+            } else {
+                // Should never happen
+                let _ = control_and_errors.send(Operation::MessageDeliveryError(
+                    "Failed to get stdin/stdout/stderr".to_string(),
+                ));
+            }
+        }
+}
+
+

--- a/src/datasink/http_upload.rs
+++ b/src/datasink/http_upload.rs
@@ -111,16 +111,9 @@ impl HttpUploadStream {
         drop(std::thread::spawn(move || {
             // get byte blobs from stream and write them to stdin.  There must be a signal for this
             // to exit, otherwise nothing will work.  So end() should send an empty array or something.
-            loop {
-                match receiving.recv() {
-                    Ok(Some(payload)) => {
-                        if let Err(err) = stdin.write_all(payload.as_bytes()) {
-                            log::debug!("Failed to write payload: {:?}", err);
-                        }
-                    }
-                    Ok(None) | Err(_) => {
-                        break;
-                    }
+            while let Ok(Some(payload)) = receiving.recv() {
+                if let Err(err) = stdin.write_all(payload.as_bytes()) {
+                    log::debug!("Failed to write payload: {:?}", err);
                 }
             }
             // Does this happen too soon?  As in, if there's enough data, will the consumer

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -92,7 +92,7 @@ impl KafkaSink {
                     );
                 })
             } else {
-                let cutoff = kafka.http_payload_limit.clone();
+                let cutoff = kafka.http_payload_limit;
                 let rest_endpoint = kafka.rest_endpoint.clone();
                 let http_proxy = kafka.http_proxy.clone();
                 let curl_cmd = if let Some(ref curl) = ini.programs.curl_cmd {
@@ -211,8 +211,8 @@ fn kafka_producer(
     let producer =
         make_sender_adapter(cfg, control_and_errors.clone()).expect("Producer creation error");
     let op = KafkaBackgroundProducer {
-        producer: producer,
-        control_and_errors: control_and_errors,
+        producer,
+        control_and_errors,
     };
     background_producer(None, sending_window, incoming_message_queue, &op);
 }

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -100,7 +100,7 @@ impl KafkaSink {
                     "curl".to_string()
                 };
                 thread::spawn(move || {
-                    http_producer(
+                    kafka_http_producer(
                         cutoff,
                         &curl_cmd,
                         &rest_endpoint,
@@ -384,9 +384,9 @@ fn make_sender_adapter(
 // environment.  The main thread does not wait for it to finish but spins up threads to handle its
 // stdin/stdout/stderr and the final wait.
 
-fn http_producer(
+fn kafka_http_producer(
     cutoff: Option<usize>,
-    cmd: &str,
+    curl_cmd: &str,
     api_endpoint: &str,
     http_proxy: &str,
     client_id: &str,
@@ -396,40 +396,68 @@ fn http_producer(
     incoming_message_queue: channel::Receiver<Message>,
     control_and_errors: channel::Sender<Operation>,
 ) {
-    let op = HttpBackgroundProducer {
-        cmd,
+    let uploader = HttpUploader::new(
+        curl_cmd,
         api_endpoint,
         http_proxy,
+        timeout,
+    );
+    let op = KafkaHttpBackgroundProducer {
+        uploader,
         client_id,
         sasl_identity: &sasl_identity,
-        timeout,
         control_and_errors,
     };
     background_producer(cutoff, sending_window, incoming_message_queue, &op);
 }
 
-struct HttpBackgroundProducer<'a> {
-    cmd: &'a str,
-    api_endpoint: &'a str,
-    http_proxy: &'a str,
+struct KafkaHttpBackgroundProducer<'a> {
+    uploader: HttpUploader,
     client_id: &'a str,
     sasl_identity: &'a Option<(String, String)>,
-    timeout: u64,
     control_and_errors: channel::Sender<Operation>,
 }
 
-impl<'a> BackgroundSender for HttpBackgroundProducer<'a> {
+impl<'a> BackgroundSender for KafkaHttpBackgroundProducer<'a> {
     fn send_all(&self, _id: usize, backlog: Vec<Msg>) {
-        http_send_messages(
-            &self.cmd,
-            &self.api_endpoint,
-            &self.http_proxy,
-            &self.client_id,
-            &self.sasl_identity,
-            self.timeout,
-            &self.control_and_errors,
-            backlog,
-        );
+        match self.uploader.start() {
+            Ok(stream) => {
+                let cred = if let Some((user, pass)) = &self.sasl_identity {
+                    format!("\"sasl-user\":\"{user}\", \"sasl-password\":\"{pass}\",")
+                } else {
+                    "".to_string()
+                };
+                let client = self.client_id.to_string();
+                for Msg {
+                    topic,
+                    key,
+                    value,
+                    ..
+                } in backlog
+                {
+                    let data_size = value.len();
+                    let ctrl = format!(
+                        "\n{{\"topic\":\"{topic}\",\"key\":\"{key}\",\"client\":\"{client}\",{cred}\"data-size\":{data_size}}}\n"
+                    );
+                    stream.put(ctrl.as_bytes());
+                    stream.put(value.as_bytes());
+                }
+                // This catches synchronous errors.  For async errors we're going to need a callback.
+                // Possibly the callback is a parameter to end().
+                match stream.end() {
+                    Ok(()) => {}
+                    Err(e) => {
+                        let _ = self.control_and_errors
+                            .send(Operation::Error(format!("Failed to send some data: {:?}", e)));
+                    }
+                }
+            }
+            Err(e) => {
+                // Not found, permission denied, etc.
+                let _ = self.control_and_errors
+                    .send(Operation::Fatal(format!("Failed to start uploader: {:?}", e)));
+            }
+        }
     }
 
     fn shutdown_delay_ms(&self) -> usize {
@@ -438,160 +466,6 @@ impl<'a> BackgroundSender for HttpBackgroundProducer<'a> {
 
     fn metadata_size(&self) -> (usize, usize) {
         // Conservative overhead for punctuation, field names, etc of the control object
-        (10 /* per batch */, 100 /* per message */)
-    }
-}
-
-// The abstraction here will be a "http poster" that encapsulates the sending method and a bunch of
-// the other stuff, and into which we can pump a bunch of data.  Then it does not matter if that
-// uses curl or some other method.  The http poster can be shared between the kafka code and the
-// pure http POST code, and has the same general shape as the kafka poster code.
-
-fn http_send_messages(
-    cmd_name: &str,
-    api_endpoint: &str,
-    http_proxy: &str,
-    client_id: &str,
-    sasl_identity: &Option<(String, String)>,
-    mut timeout: u64,
-    control_and_errors: &channel::Sender<Operation>,
-    msgs: Vec<Msg>,
-) {
-    // Curl will retry for 1s, 2s, 4s, ..., 10m and then stick to 10m
-    let mut retry_count = 0;
-    let mut next = 1;
-    while timeout > 0 {
-        timeout -= min(next, timeout);
-        next = min(600, next * 2);
-        retry_count += 1;
-    }
-    let mut args = vec![
-        "--silent".to_string(),
-        "--show-error".to_string(),
-        "--data-binary".to_string(),
-        "@-".to_string(),
-        "-H".to_string(),
-        "Content-Type: application/octet-stream".to_string(),
-    ];
-    if retry_count > 0 {
-        args.push("--retry".to_string());
-        args.push(format!("{}", retry_count));
-        args.push("--retry-connrefused".to_string());
-    }
-    args.push(api_endpoint.to_string());
-
-    // Really want to merge stdout and stderr
-    let mut cmd = std::process::Command::new(cmd_name);
-    log::debug!("Curl: {cmd_name} {:?}", args);
-    cmd.args(args)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
-    if http_proxy != "" {
-        cmd.env("http_proxy", http_proxy)
-            .env("https_proxy", http_proxy);
-    }
-    match cmd.spawn() {
-        Ok(mut child) => {
-            if let (Some(mut stdin), Some(mut stdout), Some(mut stderr)) =
-                (child.stdin.take(), child.stdout.take(), child.stderr.take())
-            {
-                let cred = if let Some((user, pass)) = sasl_identity {
-                    format!("\"sasl-user\":\"{user}\", \"sasl-password\":\"{pass}\",")
-                } else {
-                    "".to_string()
-                };
-                let client = client_id.to_string();
-                drop(std::thread::spawn(move || {
-                    for Msg {
-                        timestamp,
-                        topic,
-                        key,
-                        value,
-                    } in msgs
-                    {
-                        let _ = timestamp;
-                        let data_size = value.len();
-                        let ctrl = format!(
-                            "\n{{\"topic\":\"{topic}\",\"key\":\"{key}\",\"client\":\"{client}\",{cred}\"data-size\":{data_size}}}\n"
-                        );
-                        if let Err(err) = stdin.write_all(ctrl.as_bytes()) {
-                            log::debug!("Failed to write control object: {:?}", err);
-                        }
-                        if let Err(err) = stdin.write_all(value.as_bytes()) {
-                            log::debug!("Failed to write data blob size {data_size}: {:?}", err);
-                        }
-                    }
-                    // Does this happen too soon?  As in, if there's enough data, will the consumer
-                    // not have finished consuming?  Or will it just flush things and all will be fine?
-                    drop(stdin);
-                }));
-                // Separate threads do the output consuming and waiting for curl to finish, in order to
-                // guarantee several things:
-                //
-                //  - if the curl does not terminate immediately (because it is retrying, not
-                //    reaching the host, bandwidth-limited, ...) then Sonar does not hang waiting
-                //    for it, but can get on with its work.
-                //  - curl will not block writing its output on a full pipe
-                //  - sonar will not block on writing to curl because curl is blocked
-                //  - the child does not linger once it's ready to exit
-                //
-                // We can't use wait_with_output() because that will close stdin, and we can't wait
-                // to fork off these thread until writing has completed.  We could maybe combine the
-                // two reader threads into one using some kind of nonblocking I/O.  Maybe there are
-                // other tricks.
-                //
-                // 1K buffer is enough to see interesting errors.
-                drop(std::thread::spawn(move || {
-                    let mut buf = [0; 1024];
-                    loop {
-                        match stdout.read(&mut buf[..]) {
-                            Err(_) | Ok(0) => {
-                                break;
-                            }
-                            Ok(n) => {
-                                // This is the common case even when curl fails to deliver when
-                                // the server rejects the message.
-                                log::debug!(
-                                    "Curl succeeded with output: {}",
-                                    String::from_utf8_lossy(&buf[..n])
-                                );
-                            }
-                        }
-                    }
-                    drop(stdout);
-                }));
-                drop(std::thread::spawn(move || {
-                    let mut buf = [0; 1024];
-                    loop {
-                        match stderr.read(&mut buf[..]) {
-                            Err(_) | Ok(0) => {
-                                break;
-                            }
-                            Ok(n) => {
-                                log::debug!(
-                                    "Curl failed with output {}",
-                                    String::from_utf8_lossy(&buf[..n])
-                                );
-                            }
-                        }
-                    }
-                    drop(stderr);
-                }));
-                drop(std::thread::spawn(move || {
-                    let _ = child.wait();
-                }));
-            } else {
-                // Should never happen
-                let _ = control_and_errors.send(Operation::MessageDeliveryError(
-                    "Failed to get stdin/stdout/stderr".to_string(),
-                ));
-            }
-        }
-        Err(e) => {
-            // Not found, permission denied, etc.
-            let _ = control_and_errors
-                .send(Operation::Fatal(format!("Failed to launch curl: {:?}", e)));
-        }
+        (10 /* per batch */, 200 /* per message */)
     }
 }

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -394,12 +394,7 @@ fn kafka_http_producer(
     incoming_message_queue: channel::Receiver<Message>,
     control_and_errors: channel::Sender<Operation>,
 ) {
-    let uploader = http_upload::HttpUploader::new(
-        curl_cmd,
-        api_endpoint,
-        http_proxy,
-        timeout,
-    );
+    let uploader = http_upload::HttpUploader::new(curl_cmd, api_endpoint, http_proxy, timeout);
     let op = KafkaHttpBackgroundProducer {
         uploader,
         client_id,
@@ -427,10 +422,7 @@ impl<'a> BackgroundSender for KafkaHttpBackgroundProducer<'a> {
                 };
                 let client = self.client_id.to_string();
                 for Msg {
-                    topic,
-                    key,
-                    value,
-                    ..
+                    topic, key, value, ..
                 } in backlog
                 {
                     let data_size = value.len();
@@ -445,15 +437,18 @@ impl<'a> BackgroundSender for KafkaHttpBackgroundProducer<'a> {
                 match stream.end() {
                     Ok(()) => {}
                     Err(e) => {
-                        let _ = self.control_and_errors
+                        let _ = self
+                            .control_and_errors
                             .send(Operation::MessageDeliveryError(e));
                     }
                 }
             }
             Err(e) => {
                 // Not found, permission denied, etc.
-                let _ = self.control_and_errors
-                    .send(Operation::Fatal(format!("Failed to start uploader: {:?}", e)));
+                let _ = self.control_and_errors.send(Operation::Fatal(format!(
+                    "Failed to start uploader: {:?}",
+                    e
+                )));
             }
         }
     }

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -459,7 +459,8 @@ impl<'a> BackgroundSender for KafkaHttpBackgroundProducer<'a> {
 
     fn metadata_size(&self) -> (usize, usize) {
         // Conservative overhead for punctuation, field names, etc of the control object, note topic
-        // and key have already been accounted for by the size() method.
-        (10 /* per batch */, 100 /* per message */)
+        // and key have already been accounted for by the size() method, but other fields are
+        // surprisingly large.
+        (10 /* per batch */, 150 /* per message */)
     }
 }

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -179,9 +179,6 @@ impl ClientContext for SonarProducerContext {}
 
 const KAFKA_BUFFER_MS: usize = 1000;
 
-// kafka_producer and http_producer are both instances of a background_producer, that is parameterized by
-// "something that sends.
-
 fn kafka_producer(
     broker: String,
     client_id: String,
@@ -216,7 +213,7 @@ fn kafka_producer(
         producer: producer,
         control_and_errors: control_and_errors,
     };
-    background_producer(sending_window, incoming_message_queue, &op);
+    background_producer(None, sending_window, incoming_message_queue, &op);
 }
 
 struct KafkaBackgroundProducer {
@@ -252,6 +249,10 @@ impl BackgroundSender for KafkaBackgroundProducer {
 
     fn shutdown_delay_ms(&self) -> usize {
         KAFKA_BUFFER_MS
+    }
+
+    fn metadata_size(&self) -> (usize, usize) {
+        (0, 0)
     }
 }
 
@@ -391,9 +392,70 @@ fn http_producer(
     client_id: &str,
     sasl_identity: Option<(String, String)>,
     sending_window: u64,
-    mut timeout: u64,
+    timeout: u64,
     incoming_message_queue: channel::Receiver<Message>,
     control_and_errors: channel::Sender<Operation>,
+) {
+    let op = HttpBackgroundProducer {
+        cmd,
+        api_endpoint,
+        http_proxy,
+        client_id,
+        sasl_identity: &sasl_identity,
+        timeout,
+        control_and_errors,
+    };
+    background_producer(cutoff, sending_window, incoming_message_queue, &op);
+}
+
+struct HttpBackgroundProducer<'a> {
+    cmd: &'a str,
+    api_endpoint: &'a str,
+    http_proxy: &'a str,
+    client_id: &'a str,
+    sasl_identity: &'a Option<(String, String)>,
+    timeout: u64,
+    control_and_errors: channel::Sender<Operation>,
+}
+
+impl<'a> BackgroundSender for HttpBackgroundProducer<'a> {
+    fn send_all(&self, _id: usize, backlog: Vec<Msg>) {
+        http_send_messages(
+            &self.cmd,
+            &self.api_endpoint,
+            &self.http_proxy,
+            &self.client_id,
+            &self.sasl_identity,
+            self.timeout,
+            &self.control_and_errors,
+            backlog,
+        );
+    }
+
+    fn shutdown_delay_ms(&self) -> usize {
+        5000
+    }
+
+    fn metadata_size(&self) -> (usize, usize) {
+        // Conservative overhead for punctuation, field names, etc of the control object
+        (10 /* per batch */, 100 /* per message */)
+    }
+}
+
+// The abstraction here will be a "http poster" that encapsulates the sending method and a bunch of
+// the other stuff, and into which we can pump a bunch of data.  Then it does not matter if that
+// uses curl or some other method.  The http poster can be shared between the kafka code and the
+// pure http POST code, and has the same general shape as the kafka poster code.
+
+fn http_send_messages(
+    cmd_name: &str,
+    api_endpoint: &str,
+    http_proxy: &str,
+    client_id: &str,
+    sasl_identity: &Option<(String, String)>,
+    mut timeout: u64,
+    control_and_errors: &channel::Sender<Operation>,
+    msgs: Vec<Msg>,
 ) {
     // Curl will retry for 1s, 2s, 4s, ..., 10m and then stick to 10m
     let mut retry_count = 0;
@@ -403,119 +465,6 @@ fn http_producer(
         next = min(600, next * 2);
         retry_count += 1;
     }
-
-    let op = HttpBackgroundProducer {
-        cutoff,
-        cmd,
-        api_endpoint,
-        http_proxy,
-        client_id,
-        retry_count,
-        sasl_identity: &sasl_identity,
-        control_and_errors,
-    };
-    background_producer(sending_window, incoming_message_queue, &op);
-}
-
-struct HttpBackgroundProducer<'a> {
-    cutoff: Option<usize>,
-    cmd: &'a str,
-    api_endpoint: &'a str,
-    http_proxy: &'a str,
-    client_id: &'a str,
-    retry_count: i32,
-    sasl_identity: &'a Option<(String, String)>,
-    control_and_errors: channel::Sender<Operation>,
-}
-
-impl<'a> BackgroundSender for HttpBackgroundProducer<'a> {
-    fn send_all(&self, _id: usize, backlog: Vec<Msg>) {
-        http_send_messages(
-            self.cutoff,
-            &self.cmd,
-            &self.api_endpoint,
-            &self.http_proxy,
-            &self.client_id,
-            self.retry_count,
-            &self.sasl_identity,
-            &self.control_and_errors,
-            backlog,
-        );
-    }
-
-    fn shutdown_delay_ms(&self) -> usize {
-        5000
-    }
-}
-
-fn http_send_messages(
-    cutoff: Option<usize>,
-    cmd_name: &str,
-    api_endpoint: &str,
-    http_proxy: &str,
-    client_id: &str,
-    retry_count: i32,
-    sasl_identity: &Option<(String, String)>,
-    control_and_errors: &channel::Sender<Operation>,
-    mut backlog: Vec<Msg>,
-) {
-    if let Some(cutoff) = cutoff {
-        while backlog.len() > 0 {
-            let mut i = 0;
-            let mut sz = 0usize;
-            while i < backlog.len() {
-                // "100" is for punctuation, field names, etc, of the control object.
-                let newsz = sz + backlog[i].size() + 100;
-                if newsz >= cutoff {
-                    break;
-                }
-                sz = newsz;
-                i += 1;
-            }
-            if i == 0 {
-                log::error!(
-                    "Message of size {} is too large to send, should not happen",
-                    backlog[0].size()
-                );
-            }
-            let new_backlog = backlog.split_off(i);
-            let to_send = backlog;
-            backlog = new_backlog;
-            http_send_some_messages(
-                cmd_name,
-                api_endpoint,
-                http_proxy,
-                client_id,
-                retry_count,
-                sasl_identity,
-                control_and_errors,
-                to_send,
-            );
-        }
-    } else {
-        http_send_some_messages(
-            cmd_name,
-            api_endpoint,
-            http_proxy,
-            client_id,
-            retry_count,
-            sasl_identity,
-            control_and_errors,
-            backlog,
-        );
-    }
-}
-
-fn http_send_some_messages(
-    cmd_name: &str,
-    api_endpoint: &str,
-    http_proxy: &str,
-    client_id: &str,
-    retry_count: i32,
-    sasl_identity: &Option<(String, String)>,
-    control_and_errors: &channel::Sender<Operation>,
-    msgs: Vec<Msg>,
-) {
     let mut args = vec![
         "--silent".to_string(),
         "--show-error".to_string(),

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -437,8 +437,8 @@ impl<'a> BackgroundSender for KafkaHttpBackgroundProducer<'a> {
                     let ctrl = format!(
                         "\n{{\"topic\":\"{topic}\",\"key\":\"{key}\",\"client\":\"{client}\",{cred}\"data-size\":{data_size}}}\n"
                     );
-                    stream.put(ctrl.as_bytes());
-                    stream.put(value.as_bytes());
+                    stream.put_string(ctrl);
+                    stream.put_string(value);
                 }
                 // This catches synchronous errors.  For async errors we're going to need a callback.
                 // Possibly the callback is a parameter to start().

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -27,6 +27,7 @@
 #![allow(dead_code)]
 
 use crate::daemon::{Dur, Ini, Operation};
+use crate::datasink::background::*;
 use crate::datasink::DataSink;
 #[cfg(debug_assertions)]
 use crate::posix::time::unix_now;
@@ -46,25 +47,6 @@ use rdkafka::config::ClientConfig;
 use rdkafka::message::DeliveryResult;
 use rdkafka::producer::base_producer::ThreadedProducer;
 use rdkafka::producer::{BaseProducer, BaseRecord, NoCustomPartitioner, ProducerContext};
-
-struct Msg {
-    timestamp: u64,
-    topic: String,
-    key: String,
-    value: String,
-}
-
-impl Msg {
-    // This can return an estimate, but it's better to overestimate than underestimate.
-    fn size(&self) -> usize {
-        return self.topic.len() + self.key.len() + self.value.len() + 20;
-    }
-}
-
-enum Message {
-    Stop,
-    M(Msg),
-}
 
 pub struct KafkaSink {
     outgoing_message_queue: channel::Sender<Message>,
@@ -197,6 +179,9 @@ impl ClientContext for SonarProducerContext {}
 
 const KAFKA_BUFFER_MS: usize = 1000;
 
+// kafka_producer and http_producer are both instances of a background_producer, that is parameterized by
+// "something that sends.
+
 fn kafka_producer(
     broker: String,
     client_id: String,
@@ -227,76 +212,47 @@ fn kafka_producer(
     }
     let producer =
         make_sender_adapter(cfg, control_and_errors.clone()).expect("Producer creation error");
-
-    let mut id = 0usize;
-    let mut rng = Rng::new();
-    let mut timeout: channel::Receiver<Instant> = channel::never();
-    let mut armed = false;
-    let mut must_arm = false;
-    let mut backlog = Vec::new();
-
-    'producer_loop: loop {
-        if must_arm {
-            assert!(!armed);
-            let sleep = rng.next() as u64 % sending_window;
-            // Note, the /Sleeping {} before sending/ pattern is used by regression tests.
-            log::debug!("Sleeping {sleep} before sending");
-            timeout = channel::after(Duration::from_secs(sleep));
-            armed = true;
-            must_arm = false;
-        }
-        channel::select! {
-            recv(timeout) -> _ => {
-                armed = false;
-                // Note, the /Sending {} items/ pattern is used by regression tests.
-                log::debug!("Sending window open.  Sending {} items", backlog.len());
-                id = kafka_send_messages(&*producer, &control_and_errors, id, &backlog);
-                backlog.clear();
-            }
-            recv(incoming_message_queue) -> msg => match msg {
-                Ok(Message::M(msg)) => {
-                    backlog.push(msg);
-                    must_arm = !armed;
-                }
-                Ok(Message::Stop) | Err(_) => {
-                    _ = kafka_send_messages(&*producer, &control_and_errors, id, &backlog);
-                    break 'producer_loop;
-                }
-            }
-        }
-    }
-
-    // Best effort: give the Kafka thread an opportunity to send what it has.
-    thread::sleep(Duration::from_millis(2 * KAFKA_BUFFER_MS as u64));
+    let op = KafkaBackgroundProducer {
+        producer: producer,
+        control_and_errors: control_and_errors,
+    };
+    background_producer(sending_window, incoming_message_queue, &op);
 }
 
-fn kafka_send_messages(
-    producer: &dyn SenderAdapter,
-    control_and_errors: &channel::Sender<Operation>,
-    mut id: usize,
-    backlog: &[Msg],
-) -> usize {
-    // We always try to send everything.  Messages that fail are dropped, because the only failure
-    // is failure to be enqueued - in that case, the message is probably fatally flawed.
-    for msg in backlog.iter() {
-        id += 1; // Always give it a new ID, even if it is later dropped.
-        log::debug!("Sending to topic: {} with id {id}", msg.topic);
-        match producer.send(
-            BaseRecord::with_opaque_to(&msg.topic, id)
-                .payload(&msg.value)
-                .key(&msg.key),
-        ) {
-            Ok(()) => {}
-            Err(m) => {
-                // An error here only means that the message could not be enqueued; sending errors
-                // are discovered in the ProducerContext.  So an error here is pretty much fatal for
-                // the message, hence we drop it.
-                let msg = format!("Message #{id}: {m}");
-                let _ = control_and_errors.send(Operation::MessageDeliveryError(msg));
+struct KafkaBackgroundProducer {
+    producer: Box<dyn SenderAdapter>,
+    control_and_errors: channel::Sender<Operation>,
+}
+
+impl BackgroundSender for KafkaBackgroundProducer {
+    fn send_all(&self, mut id: usize, backlog: Vec<Msg>) {
+        // We always try to send everything.  Messages that fail are dropped, because the only failure
+        // is failure to be enqueued - in that case, the message is probably fatally flawed.
+        for msg in backlog.iter() {
+            id += 1; // Always give it a new ID, even if it is later dropped.
+            log::debug!("Sending to topic: {} with id {id}", msg.topic);
+            match self.producer.send(
+                BaseRecord::with_opaque_to(&msg.topic, id)
+                    .payload(&msg.value)
+                    .key(&msg.key),
+            ) {
+                Ok(()) => {}
+                Err(m) => {
+                    // An error here only means that the message could not be enqueued; sending errors
+                    // are discovered in the ProducerContext.  So an error here is pretty much fatal for
+                    // the message, hence we drop it.
+                    let msg = format!("Message #{id}: {m}");
+                    let _ = self
+                        .control_and_errors
+                        .send(Operation::MessageDeliveryError(msg));
+                }
             }
         }
     }
-    id
+
+    fn shutdown_delay_ms(&self) -> usize {
+        KAFKA_BUFFER_MS
+    }
 }
 
 impl ProducerContext for SonarProducerContext {
@@ -447,67 +403,49 @@ fn http_producer(
         next = min(600, next * 2);
         retry_count += 1;
     }
-    let mut rng = Rng::new();
-    let mut timeout: channel::Receiver<Instant> = channel::never();
-    let mut armed = false;
-    let mut must_arm = false;
-    let mut backlog = Vec::new();
 
-    'producer_loop: loop {
-        if must_arm {
-            assert!(!armed);
-            let sleep = rng.next() as u64 % sending_window;
-            // Note, the /Sleeping {} before sending/ pattern is used by regression tests.
-            log::debug!("Sleeping {sleep} before sending");
-            timeout = channel::after(Duration::from_secs(sleep));
-            armed = true;
-            must_arm = false;
-        }
-        channel::select! {
-            recv(timeout) -> _ => {
-                armed = false;
-                // Note, the /Sending {} items/ pattern is used by regression tests.
-                log::debug!("Sending window open.  Sending {} items", backlog.len());
-                http_send_messages(
-                    cutoff,
-                    cmd,
-                    api_endpoint,
-                    http_proxy,
-                    client_id,
-                    retry_count,
-                    &sasl_identity,
-                    &control_and_errors,
-                    backlog,
-                );
-                backlog = vec![];
-            }
-            recv(incoming_message_queue) -> msg => match msg {
-                Ok(Message::M(msg)) => {
-                    backlog.push(msg);
-                    must_arm = !armed;
-                }
-                Ok(Message::Stop) | Err(_) => {
-                    if backlog.len() > 0 {
-                        http_send_messages(
-                            cutoff,
-                            cmd,
-                            api_endpoint,
-                            http_proxy,
-                            client_id,
-                            retry_count,
-                            &sasl_identity,
-                            &control_and_errors,
-                            backlog,
-                        );
-                    }
-                    break 'producer_loop;
-                }
-            }
-        }
+    let op = HttpBackgroundProducer {
+        cutoff,
+        cmd,
+        api_endpoint,
+        http_proxy,
+        client_id,
+        retry_count,
+        sasl_identity: &sasl_identity,
+        control_and_errors,
+    };
+    background_producer(sending_window, incoming_message_queue, &op);
+}
+
+struct HttpBackgroundProducer<'a> {
+    cutoff: Option<usize>,
+    cmd: &'a str,
+    api_endpoint: &'a str,
+    http_proxy: &'a str,
+    client_id: &'a str,
+    retry_count: i32,
+    sasl_identity: &'a Option<(String, String)>,
+    control_and_errors: channel::Sender<Operation>,
+}
+
+impl<'a> BackgroundSender for HttpBackgroundProducer<'a> {
+    fn send_all(&self, _id: usize, backlog: Vec<Msg>) {
+        http_send_messages(
+            self.cutoff,
+            &self.cmd,
+            &self.api_endpoint,
+            &self.http_proxy,
+            &self.client_id,
+            self.retry_count,
+            &self.sasl_identity,
+            &self.control_and_errors,
+            backlog,
+        );
     }
 
-    // Best effort: give worker threads an opportunity to send what they have.
-    thread::sleep(Duration::from_millis(5000));
+    fn shutdown_delay_ms(&self) -> usize {
+        5000
+    }
 }
 
 fn http_send_messages(

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -249,7 +249,7 @@ impl BackgroundSender for KafkaBackgroundProducer {
     }
 
     fn shutdown_delay_ms(&self) -> usize {
-        KAFKA_BUFFER_MS
+        KAFKA_BUFFER_MS * 2
     }
 
     fn metadata_size(&self) -> (usize, usize) {
@@ -458,7 +458,8 @@ impl<'a> BackgroundSender for KafkaHttpBackgroundProducer<'a> {
     }
 
     fn metadata_size(&self) -> (usize, usize) {
-        // Conservative overhead for punctuation, field names, etc of the control object
-        (10 /* per batch */, 200 /* per message */)
+        // Conservative overhead for punctuation, field names, etc of the control object, note topic
+        // and key have already been accounted for by the size() method.
+        (10 /* per batch */, 100 /* per message */)
     }
 }

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -28,6 +28,7 @@
 
 use crate::daemon::{Dur, Ini, Operation};
 use crate::datasink::background::*;
+use crate::datasink::http_upload;
 use crate::datasink::DataSink;
 #[cfg(debug_assertions)]
 use crate::posix::time::unix_now;
@@ -379,10 +380,7 @@ fn make_sender_adapter(
     Ok(Box::new(KafkaSender::new(cfg, control_and_errors.clone())?))
 }
 
-// Http REST API sender.  The logic here is that to send a data package we fork off a curl and make
-// it send the output and handle retries, it will automatically pick up proxy settings from the
-// environment.  The main thread does not wait for it to finish but spins up threads to handle its
-// stdin/stdout/stderr and the final wait.
+// Http REST API sender.  We use our own http uploader subsystem to do the actual pushing of bits.
 
 fn kafka_http_producer(
     cutoff: Option<usize>,
@@ -396,7 +394,7 @@ fn kafka_http_producer(
     incoming_message_queue: channel::Receiver<Message>,
     control_and_errors: channel::Sender<Operation>,
 ) {
-    let uploader = HttpUploader::new(
+    let uploader = http_upload::HttpUploader::new(
         curl_cmd,
         api_endpoint,
         http_proxy,
@@ -412,7 +410,7 @@ fn kafka_http_producer(
 }
 
 struct KafkaHttpBackgroundProducer<'a> {
-    uploader: HttpUploader,
+    uploader: http_upload::HttpUploader<'a>,
     client_id: &'a str,
     sasl_identity: &'a Option<(String, String)>,
     control_and_errors: channel::Sender<Operation>,
@@ -443,12 +441,12 @@ impl<'a> BackgroundSender for KafkaHttpBackgroundProducer<'a> {
                     stream.put(value.as_bytes());
                 }
                 // This catches synchronous errors.  For async errors we're going to need a callback.
-                // Possibly the callback is a parameter to end().
+                // Possibly the callback is a parameter to start().
                 match stream.end() {
                     Ok(()) => {}
                     Err(e) => {
                         let _ = self.control_and_errors
-                            .send(Operation::Error(format!("Failed to send some data: {:?}", e)));
+                            .send(Operation::MessageDeliveryError(e));
                     }
                 }
             }

--- a/src/datasink/mod.rs
+++ b/src/datasink/mod.rs
@@ -1,3 +1,4 @@
+mod background;
 pub mod delay;
 pub mod directory;
 #[cfg(feature = "kafka")]

--- a/src/datasink/mod.rs
+++ b/src/datasink/mod.rs
@@ -3,6 +3,8 @@ mod background;
 pub mod delay;
 pub mod directory;
 #[cfg(feature = "kafka")]
+mod http_upload;
+#[cfg(feature = "kafka")]
 pub mod kafka;
 pub mod stdio;
 

--- a/src/datasink/mod.rs
+++ b/src/datasink/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "kafka")]
 mod background;
 pub mod delay;
 pub mod directory;


### PR DESCRIPTION
This splits a bunch of logic out of the Kafka code into a "background uploader" idea and a "http post" idea.  Functionality-wise this should represent no change.  I will need to test some more before landing but otherwise this is done.  Once it's done, #540 is easy.
