### PR TITLE
Fix #546 - update json spec

### DIFF
--- a/doc/NEW-FORMAT.md
+++ b/doc/NEW-FORMAT.md
@@ -382,7 +382,8 @@ it usually does not.
 
 #### **`index`** uint64
 
-Node-local card index.  See notes in preamble
+Node-local card index.  See notes in preamble.  This isn't marked "omitempty" because an
+index can be 0 and it's confusing to omit the field in that case
 
 #### **`uuid`** string
 

--- a/doc/types.spec.yaml
+++ b/doc/types.spec.yaml
@@ -148,7 +148,7 @@ SysinfoGpuCard:
     index:
       type: 'uint64'
       doc: >
-        Node-local card index.  See notes in preamble
+        Node-local card index.  See notes in preamble.  This isn't marked "omitempty" because an index can be 0 and it's confusing to omit the field in that case
     uuid:
       type: 'string'
       doc: >

--- a/src/posix/hostname.rs
+++ b/src/posix/hostname.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Origin of this code: https://github.com/svartalf/hostname.
 
 /*

--- a/src/posix/users.rs
+++ b/src/posix/users.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Origin of this code: https://github.com/ogham/rust-users.  That library is not maintained as of
 // 2024/02/22 and we need very little of it for Sonar, so the relevant bits have been moved here and
 // heavily pruned to provide only what we need.

--- a/util/formats/newfmt/decode_cluster.go
+++ b/util/formats/newfmt/decode_cluster.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/decode_jobs.go
+++ b/util/formats/newfmt/decode_jobs.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/decode_samples.go
+++ b/util/formats/newfmt/decode_samples.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/decode_sysinfo.go
+++ b/util/formats/newfmt/decode_sysinfo.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 package newfmt
 
 import (

--- a/util/formats/newfmt/types.go
+++ b/util/formats/newfmt/types.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 // This is a machine-processable and partly executable specification for the new JSON format for
 // Sonar output.  It is processable into Rust code and Markdown docs by code in ../../process-doc.
 //
@@ -377,11 +379,12 @@ type SysinfoAttributes struct {
 // NOTE: Though the power limit can change, it is reported here (as well as in sample data) because
 // it usually does not.
 type SysinfoGpuCard struct {
-	// Node-local card index.  See notes in preamble
+	// Node-local card index.  See notes in preamble.  This isn't marked "omitempty" because an
+	// index can be 0 and it's confusing to omit the field in that case
 	Index uint64 `json:"index"`
 
 	// UUID as reported by card.  See notes in preamble
-	UUID string `json:"uuid"`
+	UUID string `json:"uuid,omitempty"`
 
 	// Indicates an intra-system card address, eg PCI address
 	Address string `json:"address,omitempty"`

--- a/util/formats/newfmt_test.go
+++ b/util/formats/newfmt_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 // The purpose of this test:
 //
 // - touch every defined data field at least once and make sure it has the expected value

--- a/util/formats/testing.go
+++ b/util/formats/testing.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 package formats
 
 import (

--- a/util/kafka-proxy/kprox.go
+++ b/util/kafka-proxy/kprox.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+// Copyright (c) 2023-2026 Norwegian Ai Cloud
+
 // Kprox is a very simple Kafka REST proxy, written for Sonar but probably generally useful.
 //
 // Usage: kprox [options] [inifile-name]


### PR DESCRIPTION
Also a drive-by fix: update copyright notices on some files that are not under GPL.  Only a clarification.
