### PR TITLE
Fix #562 - Use 2024 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sonar"
 version = "0.19.0-devel"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/NordicHPC/sonar"
 
 # We want this for building RPMs reliably with older rpmbuild (as on Saga) since it can't deal with

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@ output format can most easily be be seen by diffing this file against a desired 
 
 ## Changes in v0.19.0 (on `main`)
 
+* Bug 562 - Update to Rust 2024 Edition.
 * Bug 559 - Allow the Kafka proxy to perform authorization, removing the need for configuring
   Kafka with that information.
 * Bug 556 - **IMPORTANT FUNCTIONALITY.** The Kafka proxy can also do HTTPS, it does not need to be

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18,6 +18,7 @@
 // Signal handlers place signals in the daemon's channel as events.
 
 use crate::cluster;
+use crate::datasink::DataSink;
 use crate::datasink::delay::DelaySink;
 use crate::datasink::directory::DirectorySink;
 #[cfg(feature = "http")]
@@ -25,7 +26,6 @@ use crate::datasink::http::HttpSink;
 #[cfg(feature = "kafka")]
 use crate::datasink::kafka::KafkaSink;
 use crate::datasink::stdio::StdioSink;
-use crate::datasink::DataSink;
 use crate::install_logger;
 use crate::jobsapi;
 use crate::json_tags;
@@ -924,7 +924,7 @@ fn parse_config(config_file: &str) -> Result<Ini, String> {
                     _ => {
                         return Err(format!(
                             "Invalid global.role value `{value}` - node or master required"
-                        ))
+                        ));
                     }
                 },
                 "lockdir" | "lock-directory" => {

--- a/src/datasink/http.rs
+++ b/src/datasink/http.rs
@@ -10,9 +10,9 @@
 // reality, for most nodes, traffic will be low and non-batching is not an issue.
 
 use crate::daemon::{HttpIni, Ini, Operation};
-use crate::datasink::background::{background_producer, BackgroundSender, Message, Size};
-use crate::datasink::http_upload;
 use crate::datasink::DataSink;
+use crate::datasink::background::{BackgroundSender, Message, Size, background_producer};
+use crate::datasink::http_upload;
 use crate::systemapi::SystemAPI;
 use crossbeam::channel;
 use std::thread;

--- a/src/datasink/kafka.rs
+++ b/src/datasink/kafka.rs
@@ -27,9 +27,9 @@
 #![allow(dead_code)]
 
 use crate::daemon::{Dur, Ini, Operation};
+use crate::datasink::DataSink;
 use crate::datasink::background::*;
 use crate::datasink::http_upload;
-use crate::datasink::DataSink;
 #[cfg(debug_assertions)]
 use crate::posix::time::unix_now;
 use crate::systemapi::SystemAPI;
@@ -152,7 +152,7 @@ impl DataSink for KafkaSink {
         // that will only happen if stop() has been called, and post() should never be called after
         // stop(), so in that case ignore the error here.
         let mut topic = cluster.to_string() + "." + data_tag;
-        if let Some(ref prefix) = topic_prefix {
+        if let Some(prefix) = topic_prefix {
             topic = prefix.clone() + "." + &topic;
         }
         let key = hostname.to_string();

--- a/src/datasink/stdio.rs
+++ b/src/datasink/stdio.rs
@@ -37,7 +37,7 @@ impl DataSink for StdioSink {
         hostname: &str,
         value: String,
     ) {
-        let prefix = if let Some(ref s) = topic_prefix {
+        let prefix = if let Some(s) = topic_prefix {
             s.clone() + "."
         } else {
             "".to_string()

--- a/src/gpu/amd_smi.rs
+++ b/src/gpu/amd_smi.rs
@@ -16,7 +16,7 @@ use crate::util::cstrdup::cstrdup;
 // TODO: We should use bindgen for this but not important at the moment.
 
 #[link(name = "sonar-amd", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn amdml_device_get_count(count: *mut cty::uint32_t) -> cty::c_int;
 }
 
@@ -58,9 +58,9 @@ impl Default for AmdmlCardInfo {
 }
 
 #[link(name = "sonar-amd", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn amdml_device_get_card_info(device: cty::uint32_t, buf: *mut AmdmlCardInfo)
-        -> cty::c_int;
+    -> cty::c_int;
 }
 
 #[repr(C)]
@@ -79,7 +79,7 @@ pub struct AmdmlCardState {
 }
 
 #[link(name = "sonar-amd", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn amdml_device_get_card_state(
         device: cty::uint32_t,
         buf: *mut AmdmlCardState,
@@ -97,7 +97,7 @@ pub struct AmdmlGpuProcess {
 }
 
 #[link(name = "sonar-amd", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn amdml_device_probe_processes(count: *mut cty::uint32_t) -> cty::c_int;
     pub fn amdml_get_process(index: cty::uint32_t, buf: *mut AmdmlGpuProcess) -> cty::c_int;
     pub fn amdml_free_processes();

--- a/src/gpu/fakegpu_smi.rs
+++ b/src/gpu/fakegpu_smi.rs
@@ -5,7 +5,7 @@
 use crate::gpu::{self, fakegpu::FakegpuGPU};
 use crate::ps;
 use crate::types::{Pid, Uid};
-use crate::util::cstrdup;
+use crate::util::cstrdup::cstrdup;
 
 ////// C library API //////////////////////////////////////////////////////////////////////////////
 
@@ -16,7 +16,7 @@ use crate::util::cstrdup;
 // TODO: We should use bindgen for this but not important at the moment.
 
 #[link(name = "sonar-fakegpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn fakegpu_device_get_count(count: *mut cty::uint32_t) -> cty::c_int;
 }
 
@@ -48,7 +48,7 @@ impl Default for FakegpuCardInfo {
 }
 
 #[link(name = "sonar-fakegpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn fakegpu_device_get_card_info(
         device: cty::uint32_t,
         buf: *mut FakegpuCardInfo,
@@ -69,7 +69,7 @@ pub struct FakegpuCardState {
 }
 
 #[link(name = "sonar-fakegpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn fakegpu_device_get_card_state(
         device: cty::uint32_t,
         buf: *mut FakegpuCardState,
@@ -86,7 +86,7 @@ pub struct FakegpuGpuProcess {
 }
 
 #[link(name = "sonar-fakegpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn fakegpu_device_probe_processes(
         device: cty::uint32_t,
         count: *mut cty::uint32_t,

--- a/src/gpu/habana_smi.rs
+++ b/src/gpu/habana_smi.rs
@@ -12,7 +12,7 @@ use crate::util::cstrdup::cstrdup;
 // TODO: We should use bindgen for this but not important at the moment.
 
 #[link(name = "sonar-habana", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn habana_device_get_count(count: *mut cty::uint32_t) -> cty::c_int;
 }
 
@@ -44,7 +44,7 @@ impl Default for HabanaCardInfo {
 }
 
 #[link(name = "sonar-habana", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn habana_device_get_card_info(
         device: cty::uint32_t,
         buf: *mut HabanaCardInfo,
@@ -66,7 +66,7 @@ pub struct HabanaCardState {
 }
 
 #[link(name = "sonar-habana", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn habana_device_get_card_state(
         device: cty::uint32_t,
         buf: *mut HabanaCardState,

--- a/src/gpu/nvidia_nvml.rs
+++ b/src/gpu/nvidia_nvml.rs
@@ -14,7 +14,7 @@ use crate::util::cstrdup::cstrdup;
 // TODO: We should use bindgen for this but not important at the moment.
 
 #[link(name = "sonar-nvidia", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn nvml_device_get_count(count: *mut cty::uint32_t) -> cty::c_int;
 }
 
@@ -54,7 +54,7 @@ impl Default for NvmlCardInfo {
 }
 
 #[link(name = "sonar-nvidia", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn nvml_device_get_card_info(device: cty::uint32_t, buf: *mut NvmlCardInfo) -> cty::c_int;
 }
 
@@ -83,9 +83,9 @@ pub struct NvmlCardState {
 }
 
 #[link(name = "sonar-nvidia", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn nvml_device_get_card_state(device: cty::uint32_t, buf: *mut NvmlCardState)
-        -> cty::c_int;
+    -> cty::c_int;
 }
 
 #[repr(C)]
@@ -98,7 +98,7 @@ pub struct NvmlGpuProcess {
 }
 
 #[link(name = "sonar-nvidia", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn nvml_device_probe_processes(
         device: cty::uint32_t,
         count: *mut cty::uint32_t,

--- a/src/gpu/xpu_smi.rs
+++ b/src/gpu/xpu_smi.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 // TODO: We should use bindgen for this but not important at the moment.
 
 #[link(name = "sonar-xpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn xpu_device_get_count(count: *mut cty::uint32_t) -> cty::c_int;
 }
 
@@ -50,7 +50,7 @@ impl Default for XpuCardInfo {
 }
 
 #[link(name = "sonar-xpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn xpu_device_get_card_info(device: cty::uint32_t, buf: *mut XpuCardInfo) -> cty::c_int;
 }
 
@@ -68,7 +68,7 @@ pub struct XpuCardState {
 }
 
 #[link(name = "sonar-xpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn xpu_device_get_card_state(device: cty::uint32_t, buf: *mut XpuCardState) -> cty::c_int;
 }
 
@@ -82,7 +82,7 @@ pub struct XpuGpuProcess {
 }
 
 #[link(name = "sonar-xpu", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn xpu_device_probe_processes(
         device: cty::uint32_t,
         count: *mut cty::uint32_t,

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -23,10 +23,10 @@ use std::io;
 use std::io::{Read, Write};
 use std::os::linux::fs::MetadataExt;
 use std::path;
+use std::sync::Arc;
 #[cfg(debug_assertions)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
 use signal_hook::consts::signal;
 use signal_hook::flag;

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,12 +233,12 @@ fn main() {
             topo_text_cmd,
         } => {
             let system = attach_common(system, cluster, *hostname_only);
-            let system = if let Some(ref c) = topo_svg_cmd {
+            let system = if let Some(c) = topo_svg_cmd {
                 system.with_topo_svg_cmd(c)
             } else {
                 system
             };
-            let system = if let Some(ref c) = topo_text_cmd {
+            let system = if let Some(c) = topo_text_cmd {
                 system.with_topo_text_cmd(c)
             } else {
                 system
@@ -578,11 +578,7 @@ fn command_line(args: Vec<String>) -> Commands {
 }
 
 fn bool_arg(arg: &str, _args: &[String], next: usize, opt_name: &str) -> Option<usize> {
-    if arg == opt_name {
-        Some(next)
-    } else {
-        None
-    }
+    if arg == opt_name { Some(next) } else { None }
 }
 
 fn string_arg(arg: &str, args: &[String], next: usize, opt_name: &str) -> Option<(usize, String)> {

--- a/src/output_test.rs
+++ b/src/output_test.rs
@@ -1,7 +1,7 @@
 // These are separated so as not to confuse some test code that greps output.rs for strings that
 // look like field names.
 
-use crate::output::{write_json, Array, Object, Value};
+use crate::output::{Array, Object, Value, write_json};
 
 #[test]
 pub fn test_json() {

--- a/src/pidmap.rs
+++ b/src/pidmap.rs
@@ -32,7 +32,7 @@
 // on very large and busy nodes, and typically much less than that.
 
 use crate::systemapi;
-use crate::types::{JobID, Pid, PID_MAX};
+use crate::types::{JobID, PID_MAX, Pid};
 use std::collections::HashMap;
 
 // PID_LIMIT and MIN_RANGE_SIZE are sensible for a "large enough" pid range, but can be set to

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -6,7 +6,7 @@ use crate::json_tags::*;
 use crate::output;
 use crate::systemapi;
 
-use base64::{engine::general_purpose::STANDARD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 
 use std::io;
 

--- a/src/util/command.rs
+++ b/src/util/command.rs
@@ -69,7 +69,7 @@ pub fn safe_command(
                     "Unknown internal failure",
                     &stdout_result,
                     &stderr_result,
-                )))
+                )));
             }
             Err(e) => {
                 if e.error.kind() == io::ErrorKind::TimedOut {
@@ -80,7 +80,7 @@ pub fn safe_command(
                                 "Timed out and had to be killed",
                                 &stdout_result,
                                 &stderr_result,
-                            )))
+                            )));
                         }
                         Err(e) => {
                             break Some(CmdError::InternalError(format_failure(
@@ -88,7 +88,7 @@ pub fn safe_command(
                                 format!("Unknown internal error {:?}", e).as_str(),
                                 &stdout_result,
                                 &stderr_result,
-                            )))
+                            )));
                         }
                     }
                 }
@@ -146,7 +146,9 @@ pub fn safe_command(
 fn format_failure(command: &str, root_cause: &str, stdout: &str, stderr: &str) -> String {
     if !stdout.is_empty() {
         if !stderr.is_empty() {
-            format!("COMMAND:\n{command}\nROOT CAUSE:\n{root_cause}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}")
+            format!(
+                "COMMAND:\n{command}\nROOT CAUSE:\n{root_cause}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+            )
         } else {
             format!("COMMAND:\n{command}\nROOT CAUSE:\n{root_cause}\nSTDOUT:\n{stdout}")
         }

--- a/tests/features.sh
+++ b/tests/features.sh
@@ -12,10 +12,12 @@ for amd in "" "amd"; do
     for nvidia in "" "nvidia"; do
         for xpu in "" "xpu"; do
             for habana in "" "habana"; do
-                for daemon in "" "daemon"; do
-                    features=$(join $amd $nvidia $xpu $habana $daemon)
-                    echo "no-defaults with features: $features"
-                    cargo run --no-default-features --features="$features" -- sysinfo | jq . > /dev/null
+                for fakegpu in "" "fakegpu"; do
+                    for daemon in "" "daemon"; do
+                        features=$(join $amd $nvidia $xpu $habana $daemon $fakegpu)
+                        echo "no-defaults with features: $features"
+                        cargo run --no-default-features --features="$features" -- sysinfo | jq . > /dev/null
+                    done
                 done
             done
         done


### PR DESCRIPTION
This currently fails tests/daemon-rollup2 with a panic in the pidmap.  That test has always been a little sketchy but this is not expected at all.

Other than that, this was straightforward.  The 2024 edition has some formatting tweaks so this patch has some formatting changes because of that.